### PR TITLE
RFC-4: LedgerPlugin#getFulfillment can return null

### DIFF
--- a/0004-ledger-plugin-interface/0004-ledger-plugin-interface.md
+++ b/0004-ledger-plugin-interface/0004-ledger-plugin-interface.md
@@ -22,7 +22,7 @@ This spec depends on the [ILP spec](../0003-interledger-protocol/).
 | | [**getPrefix**](#getprefix) ( ) `⇒ Promise<String>` |
 | | [**getAccount**](#getaccount) ( ) `⇒ Promise<String>` |
 | | [**getBalance**](#getbalance) ( ) <code>⇒ Promise.&lt;String></code> |
-| | [**getFulfillment**](#getfulfillment) ( transferId ) <code>⇒ Promise.&lt;String></code> |
+| | [**getFulfillment**](#getfulfillment) ( transferId ) <code>⇒ Promise.&lt;String|null></code> |
 | | [**send**](#send) ( transfer ) <code>⇒ Promise.&lt;null></code> |
 | | [**fulfillCondition**](#fulfillcondition) ( transferId, fulfillment ) <code>⇒ Promise.&lt;null></code> |
 | | [**replyToTransfer**](#replytotransfer) ( transferId, replyMessage ) <code>⇒ Promise.&lt;null></code> |
@@ -144,9 +144,11 @@ The mapping from the ILP address to the local ledger address is dependent on the
 Return a decimal string representing the current balance. Plugin must be connected, otherwise the promise should reject.
 
 #### getFulfillment
-<code>ledgerPlugin.getFulfillment( transferId ) ⇒ Promise.&lt;String></code>
+<code>ledgerPlugin.getFulfillment( transferId ) ⇒ Promise.&lt;String|null></code>
 
 Return the fulfillment of a transfer if it has already been executed.
+
+Return `null` if there is no fulfillment.
 
 #### Event: `connect`
 <code>ledgerPlugin.on('connect', () ⇒ )</code>


### PR DESCRIPTION
It returns null if there is no fulfillment (this includes the case where the transfer doesn't exist).

cc: @emschwartz 