### PR TITLE
docs(0004): add "connectors" to getInfo example

### DIFF
--- a/0004-ledger-plugin-interface/0004-ledger-plugin-interface.md
+++ b/0004-ledger-plugin-interface/0004-ledger-plugin-interface.md
@@ -129,7 +129,14 @@ Retrieve some metadata about the ledger. Plugin must be connected, otherwise the
   "precision": 10,
   "scale": 4,
   "currencyCode": "USD",
-  "currencySymbol": "$"
+  "currencySymbol": "$",
+  "connectors": [
+    {
+      "id": "http://usd-ledger.example/accounts/chloe",
+      "name": "chloe",
+      "connector": "http://usd-eur-connector.example"
+    }
+  ]
 }
 ```
 


### PR DESCRIPTION
I forgot to add `"connectors"` to the `getInfo()` example at the same time as [ConnectorInfo](https://github.com/interledger/rfcs/blob/master/0004-ledger-plugin-interface/0004-ledger-plugin-interface.md#class-connectorinfo).