### PR TITLE
ILP Addresses (RFC0015)

### DIFF
--- a/0015-ilp-addresses/0015-ilp-addresses.md
+++ b/0015-ilp-addresses/0015-ilp-addresses.md
@@ -28,7 +28,7 @@ ILP Addresses must meet the following requirements:
     - Hyphen (`-`)
 3. Each segment MUST be separated from other segments by a period character (`.`).
 4. Address prefixes MUST end in a period (`.`) character and MAY contain any number of segments after the allocation scheme prefix.
-6. Destination addresses MUST NOT end in a period (`.`) character, and MUST contain at least two segments after the allocation scheme prefix.
+5. Destination addresses MUST NOT end in a period (`.`) character, and MUST contain at least two segments after the allocation scheme prefix.
 
 The following ABNF specification defines the format for all ILP addresses and address prefixes:
 

--- a/0015-ilp-addresses/0015-ilp-addresses.md
+++ b/0015-ilp-addresses/0015-ilp-addresses.md
@@ -31,7 +31,7 @@ ILP Addresses must meet the following requirements:
 5. Destination addresses MUST NOT end in a period (`.`) character, and MUST contain at least two segments after the allocation scheme prefix.
 6. The total length of an ILP Address must be no more than **1023 characters** including the allocation scheme prefix, separators, and all segments.
 
-The following ABNF specification defines the format for all ILP addresses and address prefixes:
+The following ABNF specification defines the format for the contents of all ILP addresses and address prefixes. (You must also enforce the overal length requirement of 1023 characters or less.)
 
 ```abnf
 address     = scheme separator *prefix [segment]
@@ -51,11 +51,11 @@ You can also use the following regular expressions to verify the same requiremen
 
 | Address Type        | Regular Expression                                     |
 |:--------------------|:-------------------------------------------------------|
-| All addresses       | `^(g|private|example|peer|self|test[1-3])\.([a-zA-Z0-9_~-]+\.)*([a-zA-Z0-9_~-]+)?$` |
-| Address prefix      | `^(g|private|example|peer|self|test[1-3])\.([a-zA-Z0-9_~-]+\.)*$` |
-| Destination address | `^(g|private|example|peer|self|test[1-3])\.([a-zA-Z0-9_~-]+\.)+[a-zA-Z0-9_~-]+$` |
+| All addresses       | `(?=^.{1,1023}$)^(g|private|example|peer|self|test[1-3])[.]([a-zA-Z0-9_~-]+[.])*([a-zA-Z0-9_~-]+)?$` |
+| Address prefix      | `(?=^.{1,1023}$)^(g|private|example|peer|self|test[1-3])[.]([a-zA-Z0-9_~-]+[.])*$` |
+| Destination address | `(?=^.{1,1023}$)^(g|private|example|peer|self|test[1-3])[.]([a-zA-Z0-9_~-]+[.])+[a-zA-Z0-9_~-]+$` |
 
-(Note that neither the ABNF nor the regular expressions enforce the maximum length requirement. Remember to check that total length of the address is **1023 characters or less**.)
+(If your regular expression engine does not support lookahead, you must drop the first parenthesis and separately enforce the overall length requirement of 1023 characters or less.)
 
 ## Allocation Schemes
 

--- a/0015-ilp-addresses/0015-ilp-addresses.md
+++ b/0015-ilp-addresses/0015-ilp-addresses.md
@@ -1,0 +1,123 @@
+# ILP Addresses
+
+_ILP addresses_ provide a way route payments to their intended destination through a recursive series of hops, including any number of ILP Connectors. (This happens after the payment is set up on a higher level, such as [SPSP](../0009-simple-payment-setup-protocol/0009-simple-payment-setup-protocol.md).) Addresses can be subdivided into two categories:
+
+- **Destination Addresses** are complete addresses that can receive payments. A destination address always maps to one account in a ledger. (It can also provide more specific information, such as an invoice ID or a sub-account.) Destination addresses MUST NOT end in a period (`.`) character.
+- **Prefix Addresses** are incomplete addresses representing a group of destination addresses. Many depths of grouping are possible: groups of accounts or sub-accounts, an individual ledger or subledger, or entire neighborhoods of ledgers. Prefix addresses MUST end in a period (`.`) character. Payment setup protocols MUST reject payments to prefix addresses.
+
+Both types of address usually contain one or more period characters as separators.
+
+## Address Requirements
+
+ILP Addresses must meet the following requirements:
+
+1. The address MUST begin with a prefix indicating the allocation scheme. The only supported allocation scheme for now is the [General Allocation Scheme](#general-allocation-scheme), which uses the prefix `g.`.
+2. Each "segment" of the address MUST contain one or more of the following characters:
+    - Alphanumeric characters, upper or lower case. (Addresses are **case-sensitive** so that they can contain data encoded in formats such as base64url.)
+    - Underscore (`_`)
+    - Tilde (`~`)
+    - Hyphen (`-`)
+3. Each segment MUST be separated from other segments by a period character (`.`).
+4. Prefix addresses MUST end in a period (`.`) character and MAY contain any number of segments after the allocation scheme prefix.
+6. Destination addresses MUST NOT end in a period (`.`) character, and MUST contain at least two segments after the allocation scheme prefix.
+
+The following regular expressions summarize these requirements:
+
+| Address Type        | Regular Expression                         |
+|:--------------------|:-------------------------------------------|
+| All addresses       | `^g\.[a-zA-Z0-9._~-]*$`                    |
+| Prefix address      | `^g\.([a-zA-Z0-9_~-]+\.)*$`                |
+| Destination address | `^g\.([a-zA-Z0-9_~-]+\.)+[a-zA-Z0-9_~-]+$` |
+
+## Example Addresses
+
+`g.acme.bob` - a destination address to the account "bob" in the ledger "acme".
+
+`g.us.fed.ach.0.acmebank.swx0a0.acmecorp.sales.199.cdfa5e16-e759-4ba3-88f6-8b9dc83c1868.2` - destination address for a particular invoice, which can break down as follows:
+
+- Neighborhoods: `us`, `fed`, `ach`, `0`, `acmebank`
+- Ledger: `swx0a0`
+- Subledger: `acmecorp`
+- Account group: `sales`
+- Account: `199`
+- Interactions: `cdfa5e16-e759-4ba3-88f6-8b9dc83c1868`, `2`
+
+`g.` - the shortest possible prefix address. All entries that are in the general allocation scheme.
+
+`g.crypto.bitcoin.` - prefix address for the public Bitcoin blockchain
+
+## General Allocation Scheme
+
+The general allocation scheme for ILP Addresses is currently the only supported scheme. It uses the prefix `g.`.
+
+This scheme has no central issuing authority or mechanism, so more than one entity can use the same address. In this case, some connectors may prepare a route to a different account than intended. In this failure case, no money moves because the receiver does not send the fulfillment. Participants in the interledger can reduce the chances of encountering this failure case by choosing addresses carefully and by properly managing connectors' routing tables.
+
+To make routing work well, we recommend including the following components as segments in an address (in order):
+
+- [Neighborhoods](#neighborhoods)
+- [Payment rail](#payment-rail)
+- [Ledger prefix](#ledger-prefix)
+- [Subledger and account group](#subledger-and-account-group)
+- [Account identifier](#account-identifier)
+- [Interactions](#interactions)
+
+
+### Neighborhoods
+
+Neighborhoods have no specific meaning, but serve as a quick shortcut for routing to the right area.
+
+- For regional currencies, use a continent code from the folowing table:
+    | Segment | Continent     |
+    |:--------|:--------------|
+    | `af`    | Africa        |
+    | `as`    | Asia          |
+    | `eu`    | Europe        |
+    | `na`    | North America |
+    | `sa`    | South America |
+    | `oc`    | Oceania       |
+    | `an`    | Antarctica    |
+- For decentralized crypto-currency ledgers, use the `crypto` neighborhood.
+- For naturally-ocurring commodities or other globally-distributed currencies, use the `earth` neighborhood.
+- For currencies strongly associated with a particular international corporation, use the continent of that corporation's headquarters.
+
+It may also be useful to have 1-3 levels of "sub-neighborhoods" to group together related connectors or ledgers. We have no specific recommendations at this time.
+
+### Payment Rail
+
+The payment rail refers to a specific way some accounts or ledgers are connected outside of ILP, such as ACH in the U.S., SEPA in Europe, or other online payment systems such as PayPal or Alipay. We recommend using an all-lowercase abbreviation for the payment rail if one is applicable to the address. Examples:
+
+| Segment | Payment Rail                                                       |
+|:--------|:-------------------------------------------------------------------|
+| `ach`   | [United States Automated Clearing House](https://en.wikipedia.org/wiki/Automated_Clearing_House) |
+| `sepa`  | [Single Euro Payments Area](https://en.wikipedia.org/wiki/Single_Euro_Payments_Area) |
+
+***TODO: more rails?***
+
+### Ledger Prefix
+
+The ledger prefix is the unique name of the ledger. When doing a local delivery, the connector typically uses this segment to figure out which ledger plugin to use. As a result, it's difficult (but possible) to make a connector between two ledgers that use the same ledger prefix.
+
+### Subledger and Account Group
+
+Zero or more segments representing optional divisions within a ledger. If there are no fees involved in transferring between a ledger and a subledger, the subledger can be a "local delivery" from the connector's perspective. If fees are necessary for connecting to a subledger, it may require a connector. ***TODO: More clarifications and detailed recommendations needed.***
+
+### Account Identifier
+
+A unique identifier of the account within the ledger. The ledger plugin maps these to accounts within a ledger. For some ledgers, a simple conversion rule may suffice; other ledgers may require a lookup table. ***TODO: clarify exactly how five-bells-ledger-plugin or Common Ledger API plugin do this***
+
+### Interactions
+
+Additional segments within an address. In most cases, any segments after the account identifier are not expected to match anything in a routing table, so they won't usually affect the routing of a payment. They may be used by automated programs listening for payments to specific purposes or situations, such as invoices.
+
+_**Rome's note:** I'm not sure if we should say ledger plugins can use these segments to decide which account to route to or not. If they can, I'm not sure how useful it is to draw a distinction between this and the account identifier._
+
+
+
+# Routing
+
+_**Rome's note:** I might move this to RFC 0003 eventually._
+
+Connectors maintain a _routing table_ of ILP addresses. Routing is a recursive lookup through the routing tables of any number of connectors. When a connector receives a query, it finds the [longest prefix match](https://en.wikipedia.org/wiki/Longest_prefix_match) for the queried address. Then, it follows one of the following cases:
+
+- If the matching address is marked for local delivery, the connector prepares a transfer to that address in one of the ledgers connected to it. The connector's ledger plugin maps the ILP address to an account within the ledger. (This is the base case.)
+- If the matching address is marked as forwarded delivery, it has the address of another connector associated with it in the routing table. The connector makes a routing lookup on the connector associated with the address. (This is the recursive case.)

--- a/0015-ilp-addresses/0015-ilp-addresses.md
+++ b/0015-ilp-addresses/0015-ilp-addresses.md
@@ -1,6 +1,6 @@
 # ILP Addresses
 
-_ILP addresses_ provide a way route payments to their intended destination through a recursive series of hops, including any number of ILP Connectors. (This happens after the payment is set up on a higher level, such as [SPSP](../0009-simple-payment-setup-protocol/0009-simple-payment-setup-protocol.md).) Addresses are not meant to be user-facing, but allow several ASCII characters for easy debugging.
+_ILP addresses_ provide a way to [route](#routing) payments to their intended destination through a recursive series of hops, including any number of ILP Connectors. (This happens after the payment is set up on by a higher-level payment setup protocol such as [SPSP](../0009-simple-payment-setup-protocol/0009-simple-payment-setup-protocol.md).) Addresses are not meant to be user-facing, but allow several ASCII characters for easy debugging.
 
 Addresses can be subdivided into two categories:
 
@@ -8,6 +8,13 @@ Addresses can be subdivided into two categories:
 - **Address Prefixes** are incomplete addresses representing a group of destination addresses. Many depths of grouping are possible: groups of accounts or sub-accounts, an individual ledger or subledger, or entire neighborhoods of ledgers. Address prefixes MUST end in a period (`.`) character. Payment setup protocols MUST reject payments to address prefixes.
 
 Both types of address usually contain one or more period characters as separators.
+
+## Routing
+
+Connectors maintain a _routing table_ of ILP addresses. Routing is a recursive lookup through the routing tables of any number of connectors. When a connector receives a query, it finds the [longest prefix match](https://en.wikipedia.org/wiki/Longest_prefix_match) for the queried address. Then, it follows one of the following cases:
+
+- If the matching address is marked for local delivery, the connector prepares a transfer to that address in one of the ledgers connected to it. The connector's ledger plugin maps the ILP address to an account within the ledger. (This is the base case.)
+- If the matching address is marked as forwarded delivery, it has the address of another connector associated with it in the routing table. The connector makes a routing lookup on the connector associated with the address. (This is the recursive case.)
 
 ## Address Requirements
 
@@ -54,7 +61,7 @@ The allocation scheme is the first part of an address, which indicates how the a
 
 | Prefix                       | Allocation Scheme             | Definition and Use Case |
 |:-----------------------------|:------------------------------|:--------------|
-| `g.`                         | [General Allocation Scheme][] | Most ILP addresses used to send and receive real money. |
+| `g.`                         | [Global Allocation Scheme][]  | ILP addresses that are intended to send and receive money from any other address in the global scheme. |
 | `private.`                   | Private allocation            | For ILP addresses that only have meaning in a private subnet or intranet. Analogous to the [192.168.0.0/16 range in IPv4](https://en.wikipedia.org/wiki/Private_network). |
 | `example.`                   | Examples                      | For "non-real" addresses that are used as examples or in documentation. Analogous to ["555 phone numbers"](https://en.wikipedia.org/wiki/555_%28telephone_number%29) in the USA. |
 | `test1.`, `test2.`, `test3.` | Testing                       | For addresses used in tests, such as unit or integration tests of compatible software. |
@@ -62,97 +69,94 @@ The allocation scheme is the first part of an address, which indicates how the a
 | `peer.`                      | Peering                       | Similar to ledger-local addresses, but specifically for use in a peering relationship. The [ilp-plugin-virtual](https://github.com/interledgerjs/ilp-plugin-virtual) is an example of an existing implementation that uses this. |
 | `self.`                      | Local loopback                | For addresses that are only valid on the local machine. |
 
-## General Allocation Scheme
-[General Allocation Scheme]: #general-allocation-scheme
+## Global Allocation Scheme
+[Global Allocation Scheme]: #global-allocation-scheme
 
-The general allocation scheme for ILP Addresses is currently the only supported scheme. It uses the prefix `g.`.
+The global allocation scheme for ILP Addresses is the scheme that most addresses are expected to use. It uses the prefix `g.`. Addresses under this scheme are expected to be connected to all other such addresses, to the extent that the current trust and liquidity permit.
 
 This scheme has no central issuing authority or mechanism, so more than one entity can use the same address. In this case, some connectors may prepare a route to a different account than intended. In this failure case, no money moves because the receiver does not send the fulfillment. Participants in the interledger can reduce the chances of encountering this failure case by choosing addresses carefully and by properly managing connectors' routing tables.
 
-The general allocation scheme does not allow you to make any assumptions about the meaning of the segments. Segments in the same place could have different meanings to different ledgers or connectors. To make routing work well, we recommend placing the segments in the following order:
+The global allocation scheme does not allow you to make any assumptions about the meaning of the segments. Segments in the same place could have different meanings to different ledgers or connectors. However, to make routing work well, we recommend placing segments in the following order:
 
 - [Neighborhoods](#neighborhoods)
-- [Payment rail](#payment-rail)
-- [Ledger prefix](#ledger-prefix)
-- [Subledger and account group](#subledger-and-account-group)
-- [Account identifier](#account-identifier)
+- [Ledger prefixes](#ledger-prefixes)
+- [Account identifiers](#account-identifiers)
 - [Interactions](#interactions)
 
 Not all addresses contain all this information, and some addresses may use multiple segments to represent some of this information.
 
 ### Neighborhoods
 
-Neighborhoods have no specific meaning, but serve as a quick shortcut for routing to the right area.
+Neighborhoods have no specific meaning, but serve as a quick shortcut for routing to the right area. At this time, there is no official list of neighborhoods, but the following list of examples should illustrate what might constitute a neighborhood:
 
-- For regional currencies, use a continent code from the following table:
-    | Segment | Continent     |
-    |:--------|:--------------|
-    | `af`    | Africa        |
-    | `as`    | Asia          |
-    | `eu`    | Europe        |
-    | `na`    | North America |
-    | `sa`    | South America |
-    | `oc`    | Oceania       |
-    | `an`    | Antarctica    |
-- For decentralized crypto-currency ledgers, use the `crypto` neighborhood.
-- For naturally-ocurring commodities or other globally-distributed currencies, use the `earth` neighborhood.
-- For currencies strongly associated with a particular international corporation, use the continent of that corporation's headquarters.
+- `crypto.` for ledgers related to decentralized crypto-currencies such as Bitcoin, Etherium, or XRP.
+- `sepa.` for ledgers in the [Single Euro Payments Area](https://en.wikipedia.org/wiki/Single_Euro_Payments_Area).
+- `dev.` for Interledger Protocol development and early adopters
 
-It may also be useful to have 1-3 levels of "sub-neighborhoods" to group together related connectors or ledgers. We have no specific recommendations at this time.
+Large neighborhoods can be further subdivided into nested sub-neighborhoods; for example, `dev.luxembourg.` for development ledgers hosted in Luxembourg.
 
-### Payment Rail
 
-The payment rail refers to a specific way some accounts or ledgers are connected outside of ILP, such as ACH in the U.S., SEPA in Europe, or other online payment systems such as PayPal or Alipay. We recommend using an all-lowercase abbreviation for the payment rail if one is applicable to the address. Examples:
+### Ledger Prefixes
 
-| Segment | Payment Rail                                                       |
-|:--------|:-------------------------------------------------------------------|
-| `ach`   | [United States Automated Clearing House](https://en.wikipedia.org/wiki/Automated_Clearing_House) |
-| `sepa`  | [Single Euro Payments Area](https://en.wikipedia.org/wiki/Single_Euro_Payments_Area) |
+A ledger prefix is the unique name of the ledger. When doing a local delivery, the [ilp-connector][] reference implementation uses this segment to figure out which ledger plugin to use. As a result, it's difficult (but possible) to make a connector that directly interacts with two ledgers that use the same ledger prefix.
 
-***TODO: more rails?***
+A ledger's prefix can be multiple segments, for example if a ledger is divided into logical or physical subledgers. If fees are necessary for connecting to a subledger, payments to that subledger must be routed through a connector, although it is not necessary for the address itself to include a connector.
 
-### Ledger Prefix
+If at all possible, the ledger itself should advertise what prefix(es) are used to address it. This could be reported in a metadata API method or in official communications from the ledger operator. If a ledger cannot or does not specify its prefix, whoever is running connectors to the ledger should agree upon a prefix to use. See also: [Nested Ledgers](#nested-ledgers).
 
-The ledger prefix is the unique name of the ledger. When doing a local delivery, the connector typically uses this segment to figure out which ledger plugin to use. As a result, it's difficult (but possible) to make a connector between two ledgers that use the same ledger prefix.
+[ilp-connector]: https://github.com/interledgerjs/ilp-connector
 
-### Subledger
 
-Zero or more segments representing optional divisions within a ledger; for example, if a ledger is composed of partitions that run on different hardware, the partitions could be named here. If there are no fees involved in transferring between a ledger and a subledger, this can still be a "local delivery" from the connector's perspective.
+### Account Identifiers
 
-If fees are necessary for connecting to a subledger, payments to that subledger must be routed through a connector.
+One or more segments that serve as a unique identifier of the account within the ledger. The ledger plugin maps these to accounts within a ledger. For some ledgers, a simple conversion rule may suffice; other ledgers may require a lookup table. The [five-bells-ledger-plugin][] reference implementation translates uses one full segment exactly as the account identifier.
 
-### Account Identifier
-
-A unique identifier of the account within the ledger. The ledger plugin maps these to accounts within a ledger. For some ledgers, a simple conversion rule may suffice; other ledgers may require a lookup table. The five-bells-ledger-plugin reference implementation translates uses this full segment exactly as the account identifier.
-
-If a ledger has different groupings of accounts, it might represent them as additional segments that are effectively part of the account identifier.
+[five-bells-ledger-plugin]: https://github.com/interledgerjs/ilp-plugin-bells
 
 ### Interactions
 
-Additional segments within an address. In most cases, any segments after the account identifier are not expected to match anything in a routing table, so they won't usually affect the routing of a payment. Ledgers and ledger plugins may use the interactions segment of an address when generating notifications, so programs listening for payments can respond differently based on this portion of the address.
+Additional segments within an address. Ledgers and ledger plugins may use the interactions segment of an address when generating notifications, so programs listening for payments can respond differently based on this portion of the address. Interactions may be unique per payment or purpose.
 
-### Example General Allocation Scheme Addresses
+To prevent multiple listeners from reacting to incoming payments intended for each other, the "interactions" segment of an address should start with a segment identifying how the payment was planned.
+
+
+### Nested Ledgers
+
+A ledger can be addressed relative to another _"locator"_ ledger. Smaller and lesser-known ledgers may find it easier to advertise routes to themselves in this manner. That way, rather than needing to have the ledger known to every connector in the same large neighborhood, only the connectors attached to the locator ledger need to know how to route to the smaller connector.
+
+A connector can advertise routes to addresses that are prefixed by the connector's address in a ledger, if the connector proves it owns those addresses (for example, by sending messages using a ledger's messaging service from the account that address describes).
+
+If `example.dev.acme.blue` is an account at ACME ledger belonging to Blue Connector, Blue Connector can advertise prefixes such as `example.dev.acme.blue.waygate.` to its peer connectors that are also on ACME ledger. This way, payments that could be routed to `example.dev.acme.blue` can also be routed to accounts in the nested WayGate ledger through Blue Connector, with ACME ledger as the locator ledger. Other connectors _could_ manually add routes that shortcut to the `example.dev.acme.blue.waygate.` ledger without going through Blue Connector or ACME ledger.
+
+Using addresses that are nested this way depends on having a connector advertise the routes; if it doesn't, then only the manually-added "shortcut" routes can deliver money to addresses under the nested ledger prefix. Thus, it makes most sense if the connector at the locator ledger is operated by, or part of the same entity as, the nested ledger.
+
+
+### Example Global Allocation Scheme Addresses
 
 `g.acme.bob` - a destination address to the account "bob" in the ledger "acme".
 
-`g.us.fed.ach.0.acmebank.swx0a0.acmecorp.sales.199.cdfa5e16-e759-4ba3-88f6-8b9dc83c1868.2` - destination address for a particular invoice, which can break down as follows:
+`g.us-fed.ach.0.acmebank.swx0a0.acmecorp.sales.199.~ipr.cdfa5e16-e759-4ba3-88f6-8b9dc83c1868.2` - destination address for a particular invoice, which can break down as follows:
 
-- Neighborhoods: `us`, `fed`, `0`
-- Payment rail: `ach`
-- Ledger: `acmebank`
-- Subledger components: `swx0a0`, `acmecorp`
-- Account components: `sales`, `199`
-- Interactions: `cdfa5e16-e759-4ba3-88f6-8b9dc83c1868`, `2`
+- Neighborhoods: `us-fed.`, `0.`, `ach.`
+- Ledger prefixes: `acmebank.`, `swx0a0.`, `acmecorp.`
+- Account identifiers: `sales`, `199`
+- Interactions: `~ipr`, `cdfa5e16-e759-4ba3-88f6-8b9dc83c1868`, `2`
 
-`g.` - the shortest possible address prefix. Includes all entries that are in the general allocation scheme.
+`g.` - the shortest possible address prefix. Includes all entries that are in the global allocation scheme.
 
 `g.crypto.bitcoin.` - address prefix for the public Bitcoin blockchain
 
-# Routing
+`g.crypto.rcl.xrp.ra5nK24KXen9AHvsdFTKHSANinZseWnPcX` - Address for sending XRP to a particular user of the Ripple Consensus Ledger, which breaks down as follows:
 
-_**Rome's note:** I might move this to RFC 0003 eventually._
+- Neighborhood: `crypto.`
+- Ledger Prefixes: `rcl.`, `xrp.`
+- Account identifier: `ra5nK24KXen9AHvsdFTKHSANinZseWnPcX`
 
-Connectors maintain a _routing table_ of ILP addresses. Routing is a recursive lookup through the routing tables of any number of connectors. When a connector receives a query, it finds the [longest prefix match](https://en.wikipedia.org/wiki/Longest_prefix_match) for the queried address. Then, it follows one of the following cases:
+`g.dev.ilp-blue.blue.ilp-cyan.aquahuman.~psk.6373df86-a8d1-4aaa-930d-7d5a622913bc` - Address of a particular invoice using a nested ledger, which can break down as follows:
 
-- If the matching address is marked for local delivery, the connector prepares a transfer to that address in one of the ledgers connected to it. The connector's ledger plugin maps the ILP address to an account within the ledger. (This is the base case.)
-- If the matching address is marked as forwarded delivery, it has the address of another connector associated with it in the routing table. The connector makes a routing lookup on the connector associated with the address. (This is the recursive case.)
+- Neighborhood: `dev.`
+- Ledger prefixes (locator ledger): `ilp-blue.`
+- Connector account identifier (locator ledger): `blue.`
+- Ledger prefixes (nested ledger): `ilp-cyan.`
+- Account identifier (nested ledger): `aquahuman.`
+- Interactions: `~psk`, `6373df86-a8d1-4aaa-930d-7d5a622913bc`


### PR DESCRIPTION
This PR consolidates information from #132 and #31, plus summarizes up-to-date thoughts from the team on addresses in general.

Summary:

- Intro to what addresses are for and high-level view of how they're used for routing
- Rules for what's a valid ILP Address, including lists of currently-defined prefixes
- Descriptions of different segments and what they might be used for
- Examples and recommendations for segments