### PR TITLE
RFC-9: SPSPv2 (switch to PSK)

### DIFF
--- a/0009-simple-payment-setup-protocol/0009-simple-payment-setup-protocol.md
+++ b/0009-simple-payment-setup-protocol/0009-simple-payment-setup-protocol.md
@@ -2,17 +2,17 @@
 
 ## Preface
 
-This document describes the Simple Payment Setup Protocol (SPSP), a basic protocol for exchanging payment information between senders and recipients to set up an Interledger payment.
+This document describes the Simple Payment Setup Protocol (SPSP), a basic protocol for exchanging payment information between senders and receivers to set up an Interledger payment. SPSP uses the [Pre-Shared Key (PSK)](../0016-pre-shared-key/0016-pre-shared-key.md) transport protocol for condition generation and data encoding.
 
 ## Introduction
 
 ### Motivation
 
-The Interledger Protocol does not specify how payment details, such as the ILP Packet or Crypto Condition, should be exchanged between the sender and recipient. SPSP is a minimal protocol that uses HTTP for communicating these details.
+The Interledger Protocol does not specify how payment details, such as the ILP Packet or Crypto Condition, should be exchanged between the sender and receiver. SPSP is a minimal protocol that uses HTTPS for communicating these details.
 
 ### Scope
 
-SPSP provides for exchanging basic payment details needed by a sender to confirm the details of and set up an ILP payment. It is intended for use by end-user applications.
+SPSP provides for exchanging basic receiver details needed by a sender to set up an ILP payment. It is intended for use by end-user applications.
 
 ### Interfaces
 
@@ -22,89 +22,48 @@ SPSP messages MUST be exchanged over HTTPS.
 
 ### Operation
 
-Any SPSP recipient will create a receiving HTTP endpoint called the *receiver*. The sender can query this endpoint to get information about the type of payment that can be made to this receiver. The sender also uses the receiver endpoint to set up the ILP payment.
+Any SPSP receiver will run an SPSP server and expose an HTTPS endpoint called the SPSP Endpoint. The sender can query this endpoint to get information about the type of payment that can be made to this receiver. The sender can set up and send multiple ILP payments using the details provided by the receiver.
 
 ### Definitions
 
-#### SPSP Client
-
-The sender application that uses SPSP to interact with the SPSP Server.
-
-#### SPSP Server
-
-The server used on the recipient's side to handle SPSP requests.
-
-#### Receiver
-
-The specific HTTP endpoint on the SPSP used for setting up a payment.
+* **SPSP Client** - The sender application that uses SPSP to interact with the SPSP Server
+* **SPSP Server** - The server used on the receiver's side to handle SPSP requests
+* **SPSP Endpoint** - The specific HTTPS endpoint on the SPSP server used for setting up a payment
+* **PSK Module** - Software included in the SPSP Client and Server that implements the [Pre-Shared Key](../0016-pre-shared-key/0016-pre-shared-key.md) protocol
 
 ## Overview
 
 ### Relation to Other Protocols
 
-SPSP is used for exchanging payment information before an ILP payment is initiated. It uses the receiver generated [Interledger Payment Requests](../0011-interledger-payment-request) over HTTP.
+SPSP is used for exchanging payment information before an ILP payment is initiated. The sender and receiver use the [Pre-Shared Key (PSK)](../0016-pre-shared-key/0016-pre-shared-key.md) transport protocol to generate the condition and fulfillment. The receiver generates the shared secret to be used in PSK and communicates it to the sender over HTTPS.
 
 ### Model of Operation
 
-#### Fixed Destination Amount
+We assume that the sender knows the receiver's SPSP endpoint (see [Appendix A: (Optional) Webfinger Discovery](#appendix-a-optional-webfinger-discovery)).
 
-SPSP may be used by the sender to send a payment such that the recipient receives a specific amount of their chosen currency or asset type. The model of operation is illustrated with the following example:
-
-We assume that the sender knows the receiver endpoint (see [Appendix A: (Optional) Webfinger Discovery](#appendix-a-optional-webfinger-discovery)).
-
-1. The sender's SPSP client queries the receiver endpoint.
-2. The receiver endpoint responds with the receiver info, including the receiver's currency code.
-3. The sender chooses an amount of the receiver's asset to deliver.
-4. The sender's SPSP client submits the payment information, including the destination amount, to the receiver endpoint.
-5. The receiver endpoint responds with an [Interledger Payment Request](../0011-interledger-payment-request), which includes the execution condition.
-6. The sender's SPSP client uses its ILP module to get a quote in their currency or asset type for the ILP transfer.
-7. The sender accepts the quote.
-8. The sender's SPSP client uses its ILP module to initiate the ILP payment.
-9. The receiver's ILP module registers the incoming transfer held pending the fulfillment of the Crypto Condition. It validates that the transfer matches the packet and regenerates the condition fulfillment using the method recommended in the [Interledger Payment Request](../0011-interledger-payment-request) spec. The ILP module submits the fulfillment to execute the transfer and claim the funds.
-10. The sender's SPSP client receives a notification from its ILP module that the transfer has been executed, including the condition fulfillment from the recipient, and notifies the sender that the payment is completed.
-
-#### Fixed Source Amount
-
-SPSP may be used by the sender to send a payment of a fixed amount of the sender's chosen currency or asset type. This is illustrated with the following example:
-
-We assume that the sender knows the receiver endpoint (see [Appendix A: (Optional) Webfinger Discovery](#appendix-a-optional-webfinger-discovery)).
-
-1. The sender's SPSP client queries the receiver endpoint.
-2. The receiver endpoint responds with the receiver info, including the recipient's ILP address.
-3. The sender choses an amount of their currency or assets to send.
-4. The sender's SPSP client uses its ILP module to quote how much of the recipient's currency or asset type will be delivered to the recipient's ILP address for the given source amount.
-5. The sender accepts the quote.
-6. The sender's SPSP client submits the payment information, including the destination amount, to the receiver endpoint.
-7. The receiver endpoint responds with an [Interledger Payment Requests](../0011-interledger-payment-request), which includes the execution condition.
-8. The sender's SPSP client uses its ILP module to create a transfer **using the chosen source amount, NOT by quoting the payment request**, and attaches the ILP packet to the transfer.
-9. The receiver's ILP module registers the incoming transfer held pending the fulfillment of the Crypto Condition. It validates that the transfer matches the packet and regenerates the condition fulfillment using the method recommended in the [Interledger Payment Request](../0011-interledger-payment-request) spec. The ILP module submits the fulfillment to execute the transfer and claim the funds.
-10. The sender's SPSP client receives a notification from its ILP module that the transfer has been executed, including the condition fulfillment from the recipient, and notifies the sender that the payment is completed.
-
-#### Invoice
-
-1. The sender's SPSP client queries the receiver endpoint.
-2. The receiver endpoint responds with the receiver info, including the invoice status, amount, and currency code.
-3. The sender's SPSP client submits the sender's info, including the sender's ILP address to the receiver endpoint.
-4. The receiver endpoint responds with an [Interledger Payment Request](../0011-interledger-payment-request) corresponding to the destination amount.
-5. The sender's SPSP client uses its ILP module to get a quote in their currency or asset type for the ILP transfer.
-6. The sender accepts the quote.
-7. The sender's SPSP client uses its ILP module to initiate the ILP transfer.
-8. The receiver's ILP module registers the incoming transfer held pending the fulfillment of the Crypto Condition. It validates that the transfer matches the packet and regenerates the condition fulfillment using the method recommended in the [Interledger Payment Request](../0011-interledger-payment-request) spec. The ILP module submits the fulfillment to execute the transfer and claim the funds.
-9. The sender's SPSP client receives a notification from its ILP module that the transfer has been executed, including the condition fulfillment from the recipient, and notifies the sender that the payment is completed.
+1. The sender's SPSP Client queries the receiver's SPSP Endpoint.
+2. The SPSP Endpoint responds with the receiver info, including the receiver's ILP address and the shared secret to be used in PSK.
+3. The sender constructs an ILP payment using the receiver's ILP address.
+4. The sender uses PSK to generate the payment condition and format additional data intended for the reciever to be sent with the payment.
+5. The sender prepares a local transfer to a connector with the condition and ILP packet attached.
+6. The receiver's PSK module registers the incoming transfer, parses and validates the ILP packet and the incoming transfer.
+7. The receiver MAY submit the incoming payment to an external system for review to ensure that the funds are wanted.
+8. If the payment is expected, the receiver's PSK module submits the condition fulfillment to the ledger to execute the transfer. If not, the PSK module rejects the incoming transfer.
+9. If the receiver executed the transfer, the sender's SPSP client receives a notification from its ILP module that the transfer has been executed, including the condition fulfillment from the receiver, and notifies the sender that the payment is completed. If the receiver rejected the transfer, the sender's SPSP client receives a notification with the receiver-specified error message detailing why the payment was rejected.
 
 ## Specification
 
-The receiver endpoint is a URI used by the sender to query information about the sender and set up payments. The receiver URI MAY contain query string parameters. The sender SHOULD treat the URI as opaque.
+The SPSP endpoint is a URI used by the sender to query information about the sender and set up payments. The SPSP endpoint URI MAY contain query string parameters. The sender SHOULD treat the URI as opaque.
 
-The receiver endpoint MUST respond to HTTP `GET` and `POST` requests in the following manner:
+The SPSP Endpoint MUST respond to HTTPS `GET` requests in the following manner:
 
-### Query (`GET <receiver>`)
+### Query (`GET <SPSP Endpoint>`)
 
-The sender queries the receiver endpoint to get information about the type of payment that can be made to this receiver:
+The sender queries the SPSP endpoint to get information about the type of payment that can be made to this receiver:
 
 #### Request
 ``` http
-GET /api/receivers/bob HTTP/1.1
+GET /api/spsp/bob HTTP/1.1
 Host: red.ilpdemo.org
 Accept: application/json
 ```
@@ -115,12 +74,20 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 
 {
-  "type": "payee",
-  "account": "ilpdemo.red.bob",
-  "currency_code": "USD",
-  "currency_symbol": "$",
-  "name": "Bob Dylan",
-  "image_url": "https://red.ilpdemo.org/api/receivers/bob/profile_pic.jpg"
+  "destination_account": "example.ilpdemo.red.bob",
+  "shared_secret": "6jR5iNIVRvqeasJeCty6C-YB5X9FhSOUPCL_5nha5Vs",
+  "maximum_destination_amount": "100000",
+  "minimum_destination_amount": "10",
+  "ledger_info": {
+    "currency_code": "USD",
+    "currency_symbol": "$",
+    "scale": 2,
+    "precision": 10
+  },
+  "receiver_info": {
+    "name": "Bob Dylan",
+    "image_url": "https://red.ilpdemo.org/api/spsp/bob/profile_pic.jpg"
+  }
 }
 ```
 
@@ -141,160 +108,66 @@ The SPSP Client understands the following Cache-Control directives:
 
 | Directive     | Description                                                  |
 |:--------------|:-------------------------------------------------------------|
-| `max-age=<i>` | The client should cache this response for `<i>` seconds. `<i>` MUST be a positive integer. |
-| `no-cache`    | The client must not cache this response. (This may be useful on invoice-type receivers, which are unique per payment.) |
+| `max-age=<i>` | The client should cache this response for `<i>` seconds. `<i>` MUST be a positive integer |
+| `no-cache`    | The client must not cache this response |
 
 ##### Response Body
 
-The response body is a JSON object. The fields provided are different depending on the `type` value of the object. Possible values for `type` are:
-
-`payee`
-: This is a general receiving account for peer-to-peer payments.
-
-`invoice`
-: This is an invoice, meaning it can be paid only once and only with a specific amount.
-
-##### Payee
-
-Payee information consists of basic account details. Amounts are chosen by the sender.
-
-Example Receiver:
-``` json
-{
-  "type": "payee",
-  "account": "ilpdemo.red.bob",
-  "currency_code": "USD",
-  "currency_symbol": "$",
-  "name": "Bob Dylan",
-  "image_url": "https://red.ilpdemo.org/api/receivers/bob/profile_pic.jpg"
-}
-```
+The response body is a JSON object that includes basic account details necessary for setting up payments.
 
 | Field | Type | Description |
 |---|---|---|
-| `type` | `"payee"` | Receiver type |
-| `account` | ILP Address | ILP Address of the recipient's account |
-| `currency_code` | String | Currency code to identify the receiver's currency. Currencies that have [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) codes should use those. Sender UIs SHOULD be able to render non-standard codes |
-| `currency_symbol` | String | Symbol for the receiver's currency intended for display in the sender's UI (e.g. `"$"` or `"shares"`). Sender UIs SHOULD be able to render non-standard symbols |
-| `name` | String | Full name of the individual, company or organization the receiver represents |
-| `image_url` | HTTPS URL | URL that a picture of the recipient can be fetched from. The image MUST be square and SHOULD be 128x128 pixels. |
+| `destination_account` | [ILP Address](../0015-ilp-addresses/0015-ilp-addresses.md) | ILP Address of the receiver's account |
+| `shared_secret` | 32 bytes, [base64-url encoded](https://en.wikipedia.org/wiki/Base64#URL_applications) | The shared secret to be used in the [Pre-Shared Key protocol](../0016-pre-shared-key/0016-pre-shared-key.md) |
+| `maximum_destination_amount` | Integer String | Maximum amount, denoted in the minimum divisible units of the ledger, the receiver will accept. This amount may be determined by the ledger's maximum account balance or transfer amount. If the receiver expects a specific amount to be delivered, this may be set equal to the `minimum_destination_amount` |
+| `minimum_destination_amount` | Integer String | Minimum amount, denoted in the minimum divisible units of the ledger, the receiver will accept. This amount may be determined by the minimum transfer amount of the ledger. If the receiver expects a specific amounts to be delivered, this may be set equal to the `maximum_destination_amount` |
+| `ledger_info` | Object | Details about the destination ledger |
+| `ledger_info.currency_code` | String | Currency code to identify the receiver's currency. Currencies that have [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) codes should use those. Sender UIs SHOULD be able to render non-standard codes |
+| `ledger_info.currency_symbol` | String | Symbol for the receiver's currency intended for display in the sender's UI (e.g. `"$"` or `"shares"`). Sender UIs SHOULD be able to render non-standard symbols |
+| `ledger_info.scale` | Integer | The scale of the amounts on the destination ledger (e.g. an amount of `"1000"` with a scale of `2` translates to `10.00` units of the destination ledger's currency) |
+| `ledger_info.precision` | Integer | The maximum precision supported by the ledger |
+| `receiver_info` | Object | Arbitrary additional information about the receiver. This field has no schema and the receiver may include any fields they choose. The field names listed below are recommended merely for interoperability purposes. |
+| `receiver_info.name` | String | _(OPTIONAL)_ Full name of the individual, company or organization the receiver represents |
+| `receiver_info.image_url` | HTTPS URL | _(OPTIONAL)_ URL where the sender can get a picture representation of the receiver |
 
-If this receiver is not available, an error can be generated at this stage:
+**Note:** Currency amounts are denominated as integer strings instead of native JSON numbers to avoid losing precision during JSON parsing. Applications MUST represent these numbers in a data type that has precision equal or greater than an unsigned 64-bit integer.
+
+##### Errors
+
+###### receiver Does Not Exist
 
 ``` http
 HTTP/1.1 404 Not Found
 Content-Type: application/json
 
 {
-  "id": "InvalidReceiverIdError",
+  "id": "InvalidReceiverError",
   "message": "Invalid receiver ID"
 }
 ```
 
-##### Invoice
+### Payment Setup
 
-Invoice information includes an exact amount as well as the status of the invoice. (Invoices can only be paid once.)
+The sender uses the receiver details to create the ILP packet:
 
-Example Receiver:
-``` json
-{
-  "type": "invoice",
-  "account": "ilpdemo.red.amazon.111-7777777-1111111",
-  "currency_code": "USD",
-  "currency_symbol": "$",
-  "amount": "10.40",
-  "status": "unpaid",
-  "invoice_info": "https://www.amazon.com/gp/your-account/order-details?ie=UTF8&orderID=111-7777777-1111111"
-}
-```
+* The `account` in the ILP packet is the `destination_account` provided by the receiver
+* The `amount` is determined by the sender:
 
-| Field | Type | Description |
-|---|---|---|
-| `type` | `"invoice"` | Receiver type |
-| `account` | ILP Address | ILP Address of the recipient's account |
-| `currency_code` | String | Currency code to identify the receiver's currency. Currencies that have [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) codes should use those. Sender UIs SHOULD be able to render non-standard codes |
-| `currency_symbol` | String | Symbol for the receiver's currency intended for display in the sender's UI (e.g. `"$"` or `"shares"`). Sender UIs SHOULD be able to render non-standard symbols |
-| `amount` | Decimal String | Value of the invoice in the recipient's currency |
-| `status` | Enum: `"paid"`, `"unpaid"`, `"cancelled"` | State of the invoice |
-| `invoice_info` | URI | URI where additional information about the invoice can be found. |
+    * The sender uses the `ledger_info.scale` to determine the integer amount to include in the ILP packet (e.g. if they want the receiver to receive 10 units on their ledger, a `ledger_info.scale` value of 2 would indicate they should set the `amount` to 1000). In cases where the sender knows the integer amount the receiver should get, for example if that amount was requested by the receiver out of band, the sender does not need to use the `ledger_info.scale`
+    * The sender SHOULD NOT set an amount greater than the `maximum_destination_amount` or lower than the `minimum_destination_amount`, as this will be rejected by the receiver
+    * The sender SHOULD NOT set an amount with a precision greater than the `ledger_info.precision`, as this will be rejected by the destination ledger
 
-### Setup (`POST <receiver>`)
+* The `data` is encoded using the [Pre-Shared Key protocol](../0016-pre-shared-key/0016-pre-shared-key.md):
 
-When the sender is ready to make a payment, it submits a payment object to the receiver.
+    * The key is the `shared_secret` provided by the receiver
+    * Additional data may be included in the PSK details. SPSP data MUST be JSON.
+    * Private PSK headers SHOULD include `Content-Type: application/json` and `Content-Length: <byte length of data>`
 
-#### Request
-
-##### For a Payee
-
-``` http
-POST /api/receiver/bob HTTP/1.1
-Host: red.ilpdemo.org
-Accept: application/json
-
-{
-  "amount": "10.40",
-  "sender_identifier": "alice@blue.ilpdemo.org",
-  "memo": "Hey Bob!"
-}
-```
-
-| Field | Type | Description |
-|---|---|---|
-| `amount` | Decimal String | _Destination amount_ the receiver will receive |
-| `sender_identifier` | String | Identifier of the sender |
-| `memo` | String | Message for the recipient linked to the payment |
-
-##### For an Invoice
-
-``` http
-POST /api/receiver/bob HTTP/1.1
-Host: red.ilpdemo.org
-Accept: application/json
-
-{
-  "sender_identifier": "alice@blue.ilpdemo.org"
-}
-```
-
-| Field | Type | Description |
-|---|---|---|
-| `sender_identifier` | String | Identifier of the sender |
-
-#### Response
-``` http
-HTTP/1.1 201 Created
-Content-Type: application/json
-
-{
-    "address": "ilpdemo.red.bob.b9c4ceba-51e4-4a80-b1a7-2972383e98af",
-    "amount": "10.40",
-    "expires_at": "2016-08-16T12:00:00Z",
-    "data": {
-        "sender_identifier": "alice@blue.ilpdemo.org"
-    },
-    "additional_headers": "asdf98zxcvlknannasdpfi09qwoijasdfk09xcv009as7zxcv",
-    "condition": "cc:0:3:wey2IMPk-3MsBpbOcObIbtgIMs0f7uBMGwebg1qUeyw:32"
-}
-```
-The response is an [Interledger Payment Request](../0011-interledger-payment-request).
-
-The setup is what primes the receiver to expect the incoming payment. The receiver generates the payment request and condition the sender must use to create the ILP Packet. The fulfillment of the condition will serve as the sender's proof of payment.
-
-The receiver has the opportunity to reject an incoming payment before any funds move, for instance because of daily limits:
-
-``` http
-HTTP/1.1 422 Unprocessable Entity
-Content-Type: application/json
-
-{
-  "id": "LimitExceededError",
-  "error": "Daily incoming funds limit exceeded"
-}
-```
+Note that the sender can send as many payments as they want using the same receiver info. The sender SHOULD query the receiver again once the time indicated in the [`Cache-Control` header](#response-headers) has passed.
 
 ## Appendix A: (Optional) Webfinger Discovery
 
-Whenever possible, receiver URLs should be exchanged out-of-band and discovery should be skipped. However, in some cases, it may be useful to have a standardized user-friendly identifier. This discovery method describes how to resolve such an identifier to an SPSP receiver endpoint.
+Whenever possible, receiver URLs should be exchanged out-of-band and discovery should be skipped. However, in some cases, it may be useful to have a standardized user-friendly identifier. This discovery method describes how to resolve such an identifier to an SPSP endpoint.
 
 First, the sender uses Webfinger ([RFC 7033](https://tools.ietf.org/html/rfc7033)) to look up an identifier (e.g. `bob@red.ilpdemo.org`):
 
@@ -311,10 +184,11 @@ Content-Type: application/json
   "subject": "acct:bob@red.ilpdemo.org",
   "links": [
     {
-      "rel": "https://interledger.org/rel/receiver",
-      "href": "https://red.ilpdemo.org/api/receivers/bob"
+      "rel": "https://interledger.org/rel/spsp/v2",
+      "href": "https://red.ilpdemo.org/api/spsp/bob"
     }
   ]
 }
 ```
 [Try this request](https://red.ilpdemo.org/.well-known/webfinger?resource=acct%3Abob%40red.ilpdemo.org)
+


### PR DESCRIPTION
* use binary ILP packet format
* use PSK instead of IPR
* remove the payee/invoice distinction
* switch to integer amounts
* receiver info can be used to send multiple payments
* "receiver" now only refers to the entity receiving the payment, not the SPSP endpoint
* switch Webfinger rel to https://interledger.org/rel/spsp/v2

Depends on https://github.com/interledger/rfcs/pull/166
Resolves https://github.com/interledger/rfcs/issues/152