### PR TITLE
Docs: add dump() to LPI store

### DIFF
--- a/0004-ledger-plugin-interface/0004-ledger-plugin-interface.md
+++ b/0004-ledger-plugin-interface/0004-ledger-plugin-interface.md
@@ -663,11 +663,15 @@ Method names are based on the popular LevelUP/LevelDOWN packages.
   },
   // Fetch a value by key
   get: (key) => {
-    // Returns Promise.<Object>
+    // Returns Promise.<String>
   },
   // Delete a value by key
   del: (key) => {
     // Returns Promise.<null>
+  },
+  // Return the store as an in-memory object
+  dump: () => {
+    // Returns Promise.<Object>
   }
 }
 ```


### PR DESCRIPTION
Required by https://github.com/interledgerjs/ilp-plugin-virtual/pull/57 . Adds a `dump()` method to the plugin store that returns the plugin store as an object in memory. Plugin virtual uses this to cache its store and perform operations on it synchronously, to avoid race conditions. Implemented in the connector's plugin store in https://github.com/interledgerjs/ilp-connector/pull/326