### PR TITLE
Fixes relative links across all rfcs's.

### DIFF
--- a/scripts/generate_web.js
+++ b/scripts/generate_web.js
@@ -29,9 +29,10 @@ renderer.heading = function (text, level, raw) {
   + '>\n';
 }
 
-// Override relative links to .md files to the folder
+// Override relative links from .md files to the base folder
 // (Allows github to be linked properly, and website as well)
 renderer.link = function (href, title, text) {
+  // Converts something like `../xxxx-<anything>/xxxx-<anything>.md` to `../xxxx-<anything>`
   href = href.replace(/^(\.{2}\/\d{4}-.*)\/(\d{4}-.*\.md)$/g, '$1')
   return marked.Renderer.prototype.link.call(this, href, title, text);
 };

--- a/scripts/generate_web.js
+++ b/scripts/generate_web.js
@@ -29,6 +29,13 @@ renderer.heading = function (text, level, raw) {
   + '>\n';
 }
 
+// Override relative links to .md files to the folder
+// (Allows github to be linked properly, and website as well)
+renderer.link = function (href, title, text) {
+  href = href.replace(/^(\.{2}\/\d{4}-.*)\/(\d{4}-.*\.md)$/g, '$1')
+  return marked.Renderer.prototype.link.call(this, href, title, text);
+};
+
 let cwd = path.resolve(__dirname, '..')
 exec('rm -rf web', { cwd })
 exec('git clone git@github.com:interledger/rfcs.git --branch gh-pages --single-branch web', { cwd })


### PR DESCRIPTION
This will make links compatible with both github and Interledger website

Reading the docs from github should lead to the right content as well as reading it from the website, without changing from one another.

It changes all `../xxxx-<anything>/xxxx-<anything>.md` to `../xxxx-<anything>`