### PR TITLE
Describe live situation

### DIFF
--- a/0008-interledger-quoting-protocol/0008-interledger-quoting-protocol.md
+++ b/0008-interledger-quoting-protocol/0008-interledger-quoting-protocol.md
@@ -50,8 +50,8 @@ The message formats described here are the `data` properties of an `OutgoingMess
 |:------------------------------|:------------|:------------|
 | `source_address`              | ILP Address | Address of the source's account in the source ledger. |
 | `destination_address`         | ILP Address | Address of the destination's account in the destination ledger. |
-| `source_amount`               | String      | Fixed integer amount to debit from the source's account. (Required unless `destination_amount` specified.) |
-| `destination_amount`          | String      | Fixed integer amount to credit to the destination's account. (Required unless `source_amount` specified.) |
+| `source_amount`               | String      | Fixed float amount to debit from the source's account, expressed in the ledger's currency (not in the ledger's base unit). (Required unless `destination_amount` specified.) |
+| `destination_amount`          | String      | Fixed float amount to credit to the destination's account, expressed in the ledger's currency (not in the ledger's base unit). (Required unless `source_amount` specified.) |
 | `destination_expiry_duration` | String      | (Optional) Number of milliseconds before the transfer in the destination ledger expires. |
 | `source_expiry_duration`      | String      | (Optional) Number of milliseconds before the transfer in the source ledger expires. |
 | `slippage`                    | String      | (Optional) Custom slippage to assume for the exchange between ledgers, as a decimal proportion. Lower slippage means the payment is cheaper but more likely to fail due to market movement. |
@@ -65,7 +65,7 @@ The request must specify either `source_amount` or `destination_amount` but not 
   "method": "quote_request",
   "id": "721e4126-98a1-4974-b35a-8a8f4655f934",
   "data": {
-    "source_amount": "10025",
+    "source_amount": "1.0025",
     "source_address": "example.eur-ledger.alice",
     "destination_address": "example.usd-ledger.bob",
     "source_expiry_duration": "6000",
@@ -88,10 +88,10 @@ The request must specify either `source_amount` or `destination_amount` but not 
 |:------------------------------|:------------|:------------|
 | `source_connector_account`    | ILP Address | The address of the connector's account in the source ledger where it should receive the first transfer. |
 | `source_ledger`               | ILP Address | The address of the ILP-enabled ledger where the source account is. |
-| `source_amount`               | String      | Integer number amount of currency the connector's account should receive in the source ledger. |
+| `source_amount`               | String      | Float number amount of currency the connector's account should receive in the source ledger, expressed in the ledger's currency (not in the ledger's base unit). |
 | `source_expiry_duration`      | String      | Integer number of milliseconds between when the payment in the source ledger is prepared and when it must be executed. |
 | `destination_ledger`          | ILP Address | The address of the ILP-enabled ledger where the destination account is. |
-| `destination_amount`          | String      | Integer number amount of currency that should be received by the destination account in the destination ledger. |
+| `destination_amount`          | String      | Float number amount of currency that should be received by the destination account in the destination ledger, expressed in the ledger's currency (not in the ledger's base unit). |
 | `destination_expiry_duration` | String      | Integer number of milliseconds between when the payment in the destination ledger is prepared and when it must be executed. |
 
 ##### Example response (method = `"quote_response"`)
@@ -103,10 +103,10 @@ The request must specify either `source_amount` or `destination_amount` but not 
   "data": {
     "source_connector_account": "mark",
     "source_ledger": "example.eur-ledger.",
-    "source_amount": "10025",
+    "source_amount": "1.0025",
     "source_expiry_duration": "6000",
     "destination_ledger": "example.usd-ledger.",
-    "destination_amount": "10571",
+    "destination_amount": "1.0571",
     "destination_expiry_duration": "5000"
   }
 }

--- a/0010-connector-to-connector-protocol/0010-connector-to-connector-protocol.md
+++ b/0010-connector-to-connector-protocol/0010-connector-to-connector-protocol.md
@@ -1,1 +1,32 @@
-> Placeholder
+# Connector to Connector protocol
+
+## Discovery
+
+Connectors discover their peers through out-of-band communication, or by looking at https://connector.land and contacting the administrator of another connector.
+
+Once peered, two connectors have a ledger between them; this is often a ledger with just two accounts, often administered collaboratively by the two connectors.
+
+## Route broadcasts
+
+Connectors send each other `broadcast_routes` messages, using the message sending functionality of the ledger between them.
+
+The syntax of such a method is defined by https://github.com/interledgerjs/ilp-connector/blob/v17.0.2/schemas/RoutingUpdate.json and
+ https://github.com/interledgerjs/five-bells-shared/blob/v22.0.1/schemas/Routes.json.
+
+When a route is included in a route update from Alice to Bob, Alice is stating she will probably be able to forward a payment to that destination, if the
+source amount which Bob would send her is high enough, given the destination amount, and as described by the `points` piece-wise linear function, and if
+liquidity permits.
+
+This means that even if the points series in a broadcasted route gives values for higher amounts, routability is still conditional on Bob's balance being
+sufficient when he tries to send a payment over the announced route, and Alice's balance on the next ledger being sufficient,
+and the next connector's balance on the next ledger, etcetera.
+
+Connectors also exchange quote requests, in the same way users may request a quote from a connector, see [IL-RFC 8](../0008-interledger-quoting-protocol/0008-interledger-quoting-protocol.md).
+
+Note that, although Transfers and ledger plugin Balances are now all expressed in integer ledger units, the points series ("liquidity curves") in route broadcasts, as well as the
+amounts in quote requests and quote responses, are still expressed in float values in the `currency_code` of the ledger. This means you will need to multiply/divide
+by `10 ** currency_scale` for the ledger in question, to convert floats (in the currency) to integers (in ledger units), and back.
+
+## Please expand this document
+
+This document is a stub, please help expand it! See https://github.com/interledger/rfcs.


### PR DESCRIPTION
Two commits:
* a few words about C2C (still a minimal stub, just enough to get the reader on their way)
* describe how ILQP *currently* works on the public Interledger.

This one change is the only place where the rfcs repo was still ahead of reality, so with this, we're really switching the rfcs repo from *prescribing* ("soll") to *describing* ("ist"). From now on, we could line up RFC PRs with implementation PRs, and merge code+docs at the same time.