### PR TITLE
Remove regexes from table for MD compatibility

### DIFF
--- a/0015-ilp-addresses/0015-ilp-addresses.md
+++ b/0015-ilp-addresses/0015-ilp-addresses.md
@@ -49,11 +49,17 @@ segment     = 1*( ALPHA / DIGIT / "_" / "~" / "-" )
 
 You can also use the following regular expressions to verify the same requirements:
 
-| Address Type        | Regular Expression                                     |
-|:--------------------|:-------------------------------------------------------|
-| All addresses       | `(?=^.{1,1023}$)^(g|private|example|peer|self|test[1-3])[.]([a-zA-Z0-9_~-]+[.])*([a-zA-Z0-9_~-]+)?$` |
-| Address prefix      | `(?=^.{1,1023}$)^(g|private|example|peer|self|test[1-3])[.]([a-zA-Z0-9_~-]+[.])*$` |
-| Destination address | `(?=^.{1,1023}$)^(g|private|example|peer|self|test[1-3])[.]([a-zA-Z0-9_~-]+[.])+[a-zA-Z0-9_~-]+$` |
+All Addresses:
+
+    (?=^.{1,1023}$)^(g|private|example|peer|self|test[1-3])[.]([a-zA-Z0-9_~-]+[.])*([a-zA-Z0-9_~-]+)?$
+    
+Address prefix:
+
+    (?=^.{1,1023}$)^(g|private|example|peer|self|test[1-3])[.]([a-zA-Z0-9_~-]+[.])*$
+
+Destination address
+
+    (?=^.{1,1023}$)^(g|private|example|peer|self|test[1-3])[.]([a-zA-Z0-9_~-]+[.])+[a-zA-Z0-9_~-]+$
 
 (If your regular expression engine does not support lookahead, you must drop the first parenthesis and separately enforce the overall length requirement of 1023 characters or less.)
 


### PR DESCRIPTION
Since [GitHub changed their parser][1], [pipe characters in tables must now be escaped][2] even if they are part of inline code items. Since some other parsers don't work this way, the best way to solve this is to avoid using the regular expression in a table. Since the regexes for recognizing addresses are rather long anyway, taking them out of the table also reduces the chances they overflow off the side of the screen/column.

[1]: https://githubengineering.com/a-formal-spec-for-github-markdown/
[2]: https://github.github.com/gfm/#tables-extension-