### PR TITLE
fix: clarify role of timeout

### DIFF
--- a/0003-interledger-protocol/0003-interledger-protocol.md
+++ b/0003-interledger-protocol/0003-interledger-protocol.md
@@ -1,6 +1,6 @@
 ---
 title: The Interledger Protocol (ILP)
-draft: 1
+draft: 2
 ---
 # Interledger Protocol (ILP)
 

--- a/0003-interledger-protocol/0003-interledger-protocol.md
+++ b/0003-interledger-protocol/0003-interledger-protocol.md
@@ -68,7 +68,7 @@ The protocol uses transfer holds to ensure a sender's funds are delivered to the
                 Local Ledger 1          Local Ledger 2
 
 
-1. The sending application uses a higher-level protocol to negotiate the address, an amount, and a cryptographic condition with the destination. It calls on the interledger module to send a payment with these parameters.
+1. The sending application uses a higher-level protocol to negotiate the address, an amount, a cryptographic condition, and a timeout with the destination. It calls on the interledger module to send a payment with these parameters.
 
 2. The interledger module prepares the ILP packet, chooses the account to send the local ledger transfer to, and passes them to the local ledger interface.
 


### PR DESCRIPTION
It's not enough for the sender to negotiate the address, an amount, and a cryptographic condition with the destination.
In HTLAs, the condition is never absolute, it's always tied to a timeout, as well.