### PR TITLE
feat: fix a time format and zone for Interledger Timestamp

### DIFF
--- a/0003-interledger-protocol/0003-interledger-protocol.md
+++ b/0003-interledger-protocol/0003-interledger-protocol.md
@@ -234,7 +234,7 @@ Implementations of ILP SHOULD NOT depend on the `name` instead of the `code`. Th
 
     Timestamp ::= GeneralizedTime
 
-Date and time when the error was initially emitted.
+Date and time when the error was initially emitted. This MUST be expressed in the UTC + 0 (Z) timezone.
 
 #### data
 

--- a/0003-interledger-protocol/0003-interledger-protocol.md
+++ b/0003-interledger-protocol/0003-interledger-protocol.md
@@ -1,6 +1,6 @@
 ---
 title: The Interledger Protocol (ILP)
-draft: 2
+draft: 3
 ---
 # Interledger Protocol (ILP)
 

--- a/0008-interledger-quoting-protocol/0008-interledger-quoting-protocol.md
+++ b/0008-interledger-quoting-protocol/0008-interledger-quoting-protocol.md
@@ -1,6 +1,6 @@
 ---
 title: The Interledger Quoting Protocol (ILQP)
-draft: 1
+draft: 2
 ---
 # Interledger Quoting Protocol (ILQP)
 

--- a/0008-interledger-quoting-protocol/0008-interledger-quoting-protocol.md
+++ b/0008-interledger-quoting-protocol/0008-interledger-quoting-protocol.md
@@ -57,7 +57,7 @@ See [interledgerjs/ilp-packet](https://github.com/interledgerjs/ilp-packet/) for
 | liquidity | LiquidityCurve | Curve describing the liquidity for the quoted route |
 | appliesToPrefix | Address | Common prefix of all addresses for which this liquidity curve applies. |
 | sourceHoldDuration | UInt32 | How long the sender should put the money on hold (in milliseconds) |
-| expiresAt | Timestamp | Maximum time where the connector expects to be able to honor this liquidity curve |
+| expiresAt | Timestamp | Maximum time where the connector expects to be able to honor this liquidity curve. This MUST be expressed in the UTC + 0 (Z) timezone. |
 
 `LiquidityCurve` is encoded as a `SEQUENCE OF SEQUENCE { x UInt64, y UInt64 }`. This is a binary format, so for example the curve `[ [0, 0], [10, 265] ]` is equivalent to the base64-encoded string `"AAAAAAAAAAAAAAAAAAAAAAAAAAAKAAAAAAAAAAkBAAA="`.
 

--- a/asn1/InterledgerTypes.asn
+++ b/asn1/InterledgerTypes.asn
@@ -36,6 +36,9 @@ Address ::= IA5String
 -- Interledger protocols depend on causality, we cannot use POSIX time and
 -- since we do not wish to create our own time standard, we end up using ISO
 -- 8601.
+-- Implementations MUST express timestamps in the format 'YYYYMMDDTHHmmSS.fffZ'
+-- compatible with RFC 3339, with fixed upper-case 'T' and 'Z', with all times
+-- expressed in the 'Z' timezone - a UTC offset of 00:00.
 
 Timestamp ::= GeneralizedTime
 

--- a/asn1/InterledgerTypes.asn
+++ b/asn1/InterledgerTypes.asn
@@ -36,9 +36,9 @@ Address ::= IA5String
 -- Interledger protocols depend on causality, we cannot use POSIX time and
 -- since we do not wish to create our own time standard, we end up using ISO
 -- 8601.
--- Implementations MUST express timestamps in the format 'YYYYMMDDTHHmmSS.fffZ'
--- compatible with RFC 3339, with fixed upper-case 'T' and 'Z', with all times
--- expressed in the 'Z' timezone - a UTC offset of 00:00.
+-- Implementations MUST express timestamps in the format 'YYYYMMDDHHmmSS.fffZ'
+-- similar to RFC 3339, with fixed uppercase 'Z'. All times MUST be expressed
+-- in the 'Z' timezone - i.e. a UTC offset of 00:00.
 
 Timestamp ::= GeneralizedTime
 


### PR DESCRIPTION
Hi,

Referring to  #230, and some discussion in #249, the various specs should explicitly mandate the time format and timezone to be used - in a nutshell, the OER GeneralizedTime type is too general and could be misused. Mandating a common time format and timezone should remove some of the potential problems.
