### PR TITLE
docs(21): make RPC API into LPI-over-HTTP

### DIFF
--- a/0004-ledger-plugin-interface/0004-ledger-plugin-interface.md
+++ b/0004-ledger-plugin-interface/0004-ledger-plugin-interface.md
@@ -1,6 +1,6 @@
 ---
 title: The Javascript Ledger Plugin Interface
-draft: 2
+draft: 3
 ---
 # Javascript Ledger Plugin Interface
 
@@ -30,6 +30,7 @@ This spec depends on the [ILP spec](../0003-interledger-protocol/).
 | | [**sendRequest**](#sendrequest) ( message ) <code>⇒ Promise.&lt;[Message](#class-message)></code> |
 | | [**fulfillCondition**](#fulfillcondition) ( transferId, fulfillment ) <code>⇒ Promise.&lt;null></code> |
 | | [**rejectIncomingTransfer**](#rejectincomingtransfer) ( transferId, reason ) <code>⇒ Promise.&lt;null></code> |
+| | [**cancelIncomingTransfer**](#cancelincomingtransfer) ( transferId, reason ) <code>⇒ Promise.&lt;null></code> |
 | | [**registerRequestHandler**](#registerrequesthandler) ( requestHandler ) <code>⇒ null</code> |
 | | [**deregisterRequestHandler**](#deregisterrequesthandler) ( ) <code>⇒ null</code> |
 
@@ -297,6 +298,11 @@ if transfer is not conditional.
 
 This MAY be used by receivers or connectors to reject incoming funds if they will not fulfill the condition or are unable to forward the payment. Previous hops in an Interledger transfer would have their money returned before the expiry and the sender or previous connectors MAY retry and reroute the transfer through an alternate path.
 
+#### cancelIncomingTransfer
+<code>ledgerPlugin.cancelIncomingTransfer( **transferId**:String, **reason**:[RejectionMessage](#class-rejectionmessage) ) ⇒ Promise.&lt;null></code>
+
+Cancel an incoming transfer.
+
 #### registerRequestHandler
 <code>ledgerPlugin.registerRequestHandler( **requestHandler**: ( request: [Message](#class-message) ) ⇒ Promise&lt;[Message](#class-message)> ) ⇒ null</code>
 
@@ -471,14 +477,20 @@ left undefined (but not any other false-y value) if unused.
 | `String` | [from](#transferfrom) | ILP Address of the source account |
 | `String` | [to](#transferto) | ILP Address of the destination account |
 | `String` | [ledger](#transferledger) | ILP Address prefix of the ledger |
-| `String` | [amount](#transferamount) | Integer transfer amount, in the ledger's base unit |
+| `String` | [amount](#transferamount) | (always required) Integer transfer amount, in the ledger's base unit |
 | `String` | [ilp](#transferilp) | Base64-encoded ILP packet |
-| `Object` | [noteToSelf](#transfernotetoself) | Host-provided memo that should be stored with the transfer |
+| `Object` | [noteToSelf](#transfernotetoself) | (always optional) Host-provided memo that should be stored with the transfer |
 | `String` | [executionCondition](#transferexecutioncondition) | Cryptographic hold condition |
 | `String` | [expiresAt](#transferexpiresat) | Expiry time of the cryptographic hold |
-| `Object` | [custom](#transfercustom) | Object containing ledger plugin specific options |
+| `Object` | [custom](#transfercustom) | (always optional) Object containing ledger plugin specific options |
 
 ### Fields
+
+The `custom` and `noteToself` fields are always optional.
+Some ledger plugins may allow unconditional transfers, for which `executionCondition`, `expiresAt` and possibly also `id` can be omitted.
+Some ledger plugins may support local transfers for which `ilp` is omitted.
+Some ledgers may not require the `from`, `to`, and/or `ledger` fields, for instance if those are always the same anyway for every transfer.
+The only field that is always required, even for unconditional transfers, is `amount`.
 
 #### Transfer#id
 <code>**id**:String</code>
@@ -587,6 +599,10 @@ The `Message` class is used to describe local ledger message. All fields are req
 | `String` | [ilp](#messageilp) | Base64-encoded ILP packet |
 | `Object` | [custom](#messagecustom) | Object containing ledger plugin specific options |
 
+Either `ilp` or `custom` (but not both) should always be included.
+Some ledger plugins may allow `id` to be omitted.
+Some ledgers may not require the `from`, `to`, and/or `ledger` fields, for instance if those are always the same anyway for every message.
+
 #### Message#id
 <code>**id**:String</code>
 
@@ -649,6 +665,8 @@ Metadata describing the ledger. This data is returned by the [`getInfo`](#getinf
 | `String` | [maxBalance](#ledgerinfomaxbalance-optional) | Integer String, for instance `"1000000000000"`, indicating the maximum balance. Optional, defaults to plus infinity. |
 
 ### Fields
+
+The `prefix`, `currencyCode`, `currencyScale` and `connectors` fields are all required.
 
 #### LedgerInfo#prefix
 <code>**prefix**:String</code>


### PR DESCRIPTION
A thought that came up in the discussion around #251 is that one way for a server-to-server protocol to become more "final" would be if it would converge ever further to the LPI.

Possible advantages of LPI-over-HTTP, compared to LLL:
* it doesn't have to be defined method-for-method, and it changes along with the LPI's versioning
* even if OER over TCP seems better than JSON over HTTP for reasons explained in #249, server APIs are usually defined as JSON over HTTP, even when there are compelling reasons to choose something more low-level (for instance, the [DropBox API](https://www.dropbox.com/developers/documentation/http/documentation#formats) or [git over https](https://git-scm.com/book/id/v2/Git-on-the-Server-The-Protocols))
* it should be easy to use in any language in which integrating with remote servers is generally easy.
* I think it's more aligned with what a developer would expect. I would be surprised if I want to integrate my app with e.g. Uber or OpenStreetMap or Facebook, and I find that any such service would have anything else than a "normal" json-over-http API.
* it's easy to use in the browser from client-side apps (think ilp-kit without server-side rendering)
* LPI is already defined, and aligning RPC more fully with LPI would make [ilp-frog](https://github.com/michielbdejong/ilp-frog/blob/master/index.js) even simpler, whereas LLL would still need to be developed and implemented.
* LLL would feel like adding a new plugin; LPI-over-http would have more claim to a special status as the default way to connect, say, a connector written in Python, to an external plugin that makes use of a JavaScript ledger plugin.