### PR TITLE
fix: include the correct class name

### DIFF
--- a/asn1/GenericPacket.asn
+++ b/asn1/GenericPacket.asn
@@ -8,7 +8,7 @@ IMPORTS
     VarBytes
     FROM GenericTypes
 
-    InterledgerProtocolPaymentMessage,
+    InterledgerProtocolPayment,
     InterledgerProtocolError
     FROM InterledgerProtocol
 


### PR DESCRIPTION
* [InterledgerProtocolPayment](https://github.com/interledger/rfcs/blob/master/asn1/GenericPacket.asn#L30) is what can be wrapped inside an ILP packet
* [InterledgerProtocolPayment](https://github.com/interledger/rfcs/blob/master/asn1/InterledgerProtocol.asn#L15) is also what has been defined.
* Yet [InterledgerProtocolPaymentMessage](https://github.com/interledger/rfcs/blob/master/asn1/GenericPacket.asn#L11) is what the GenericPacket doc tries to include from the InterledgerProtocol doc.