### PR TITLE
Proposal: Interledger RPC (instead of LLL)

### DIFF
--- a/asn1/GenericPacket.asn
+++ b/asn1/GenericPacket.asn
@@ -19,6 +19,17 @@ IMPORTS
     QuoteByDestinationAmountRequest,
     QuoteByDestinationAmountResponse
     FROM InterledgerQuotingProtocol
+
+    Transfer,
+    ConditionalTransfer,
+    ConditionFulfillment,
+    TransferStateRequest,
+    TransferStateResponse,
+    FROM TransferProtocol
+
+    Ack,
+    CustomMessage
+    FROM InterledgerTypes
 ;
 
 PACKET ::= CLASS {
@@ -34,7 +45,14 @@ PacketSet PACKET ::= {
     {5 QuoteBySourceAmountResponse} |
     {6 QuoteByDestinationAmountRequest} |
     {7 QuoteByDestinationAmountResponse} |
-    {8 InterledgerProtocolError}
+    {8 InterledgerProtocolError} |
+    {9 Transfer } |
+    {10 ConditionalTransfer } |
+    {11 ConditionFulfillment } |
+    {12 TransferStateRequest } |
+    {13 TransferStateResponse } |
+    {14 Ack } |
+    {15 CustomMessage }
 }
 
 InterledgerPacket ::= SEQUENCE {

--- a/asn1/InterledgerRPC.asn
+++ b/asn1/InterledgerRPC.asn
@@ -1,0 +1,33 @@
+LedgerLedgerLotocol
+DEFINITIONS
+AUTOMATIC TAGS ::=
+BEGIN
+
+IMPORTS
+    UInt32
+    FROM GenericTypes
+
+    Address,
+    CustomMessage
+    FROM InterledgerTypes
+
+    InterledgerPacket
+    FROM GenericPacket
+;
+
+InterledgerRpc ::= SEQUENCE {
+    -- to and from can be empty strings if they can be
+    -- inferred from the context
+    to Address,
+    from Address,
+    -- Used to associate requests and corresponding responses
+    -- If requestId = 0, the server MUST not send a response
+    requestId UInt32,
+    packet InterledgerPacket,
+    -- Additional data for protocol extensibility
+    sideProtocolData SEQUENCE OF CustomMessage
+}
+-- Note: any RPC call can be turned into a paid (or conditionally paid) request
+-- by setting the packet to either a Transfer or a ConditionalTransfer
+
+END

--- a/asn1/InterledgerTypes.asn
+++ b/asn1/InterledgerTypes.asn
@@ -25,7 +25,7 @@ Address ::= IA5String
         | "a".."z"
         | tilde )
     )
-    (SIZE (1..1023))
+    (SIZE (0..1023))
 
 -- --------------------------------------------------------------------------
 
@@ -69,5 +69,16 @@ LiquidityCurve ::= SEQUENCE OF SEQUENCE {
   x UInt64,
   y UInt64
 }
+
+Ack ::= NULL
+
+CustomMessage ::= {
+  type IA5String,
+  -- mimeType SHOULD be defined but it MAY be an empty string if
+  -- the encoding is implied by the type
+  mimeType IA5String,
+  data OCTET STRING (SIZE (0..32767))
+}
+
 
 END

--- a/asn1/TransferProtocol.asn
+++ b/asn1/TransferProtocol.asn
@@ -1,0 +1,58 @@
+TransferProtocol
+DEFINITIONS
+AUTOMATIC TAGS ::=
+BEGIN
+
+IMPORTS
+    UInt64,
+    UInt128,
+    UInt256
+    FROM GenericTypes
+
+    Timestamp
+    FROM InterledgerTypes
+
+    InterledgerPacket
+    FROM GenericPacket
+
+    InterledgerProtocolError
+    FROM InterledgerProtocol
+;
+
+-- TODO: is it too strange for a Transfer to be an InterledgerPacket itself?
+-- (that means you technically could include a Transfer in a Transfer)
+Transfer ::= SEQUENCE {
+  transferId UInt128,
+  amount UInt64,
+  packet InterledgerPacket
+  -- TODO: is it worth putting extensions?
+}
+
+ConditionalTransfer ::= SEQUENCE {
+  transferId UInt128,
+  amount UInt64,
+  packet InterledgerPacket,
+  expiresAt Timestamp,
+  executionCondition UInt256
+}
+
+ConditionFulfillment ::= SEQUENCE {
+  transferId UInt128,
+  fulfillment UInt256
+}
+
+TransferStateRequest ::= SEQUENCE {
+  transferId UInt128
+}
+
+TransferStateResponse ::= SEQUENCE {
+  -- TODO: is it worth having this in a sequence?
+  state CHOICE {
+    fulfillment UInt256,
+    rejectionReason InterledgerProtocolError,
+    prepared NULL,
+    nonExistent NULL
+  }
+}
+
+END


### PR DESCRIPTION
slightly different take on https://github.com/interledger/rfcs/pull/251 and https://github.com/interledger/rfcs/pull/256
based on conversations with @michielbdejong, @sharafian, @justmoon

By separating the transfer contents from whether they are part of a
bilateral (e.g. trustline) or multilateral (e.g. centralized ledger)
relationship, the transfer protocol becomes much more general and thus
makes sense to include alongside the "core" ILP data formats.

`InterledgerRpc` wraps the `InterledgerPacket` types in an envelope that
adds a `to`, `from` (either or both of which can be set to empty strings if
they are implied, as is the case in a bilateral connection), a `requestId`
to correlate requests and responses, and `sideProtocolData` for
extensibility.

Any type of `InterledgerRpc` request can become a paid request by
including a `Transfer` or `ConditionalTransfer` in it (which themselves can
contain other `InterledgerPacket`s -- `InterledgerProtocolPayment`s or any
other type of data that you might want/need to pay for).