### PR TITLE
LLL with ILP packet payloads

### DIFF
--- a/asn1/GenericPacket.asn
+++ b/asn1/GenericPacket.asn
@@ -9,7 +9,8 @@ IMPORTS
     FROM GenericTypes
 
     InterledgerProtocolPaymentMessage,
-    InterledgerProtocolError
+    InterledgerProtocolError,
+    InterledgerSideProtocolData,
     FROM InterledgerProtocol
 
     QuoteLiquidityRequest,
@@ -34,7 +35,8 @@ PacketSet PACKET ::= {
     {5 QuoteBySourceAmountResponse} |
     {6 QuoteByDestinationAmountRequest} |
     {7 QuoteByDestinationAmountResponse} |
-    {8 InterledgerProtocolError}
+    {8 InterledgerProtocolError} |
+    {9 InterledgerSideProtocolData}
 }
 
 InterledgerPacket ::= SEQUENCE {

--- a/asn1/InterledgerProtocol.asn
+++ b/asn1/InterledgerProtocol.asn
@@ -40,4 +40,9 @@ InterledgerProtocolError ::= SEQUENCE {
     data OCTET STRING (SIZE (0..8192))
 }
 
+InterledgerSideProtocolData ::= SEQUENCE OF SEQUENCE {
+  protocolName IA5String,
+  protocolData OCTET STRING
+}
+
 END

--- a/asn1/LedgerLedgerLotocol.asn
+++ b/asn1/LedgerLedgerLotocol.asn
@@ -16,87 +16,88 @@ IMPORTS
     FROM InterledgerTypes
 ;
 
-SideProtocolData ::= SEQUENCE OF SEQUENCE {
-  protocolName IA5String,
-  protocolData OCTET STRING
+FreeRequest ::= SEQUENCE {
+    -- Used to associate requests and corresponding responses
+    -- MUST be either zero and non-repeating
+    -- If requestId = 0, the server MUST not send a response
+    requestId UInt128,
+    packet InterledgerPacket
 }
 
-PacketRequest ::= SEQUENCE {
-  packet InterledgerPacket,
-  -- Additional data for protocol extensibility
-  sideProtocolData SideProtocolData
+FreeResponse ::= SEQUENCE {
+    -- Used to associate response to earlier FreeRequest
+    requestIdRef UInt128,
+    packet InterledgerPacket
 }
 
-PacketResponse ::= SEQUENCE {
-  packet InterledgerPacket,
-  -- Additional data for protocol extensibility
-  sideProtocolData SideProtocolData
+PaidRequest ::= SEQUENCE {
+    -- Used to associate requests and corresponding responses
+    -- MUST be either zero and non-repeating
+    -- If requestId = 0, the server MUST not send a response
+    requestId UInt128,
+    amount UInt64,
+    packet InterledgerPacket
+}
+
+PaidResponse ::= SEQUENCE {
+    -- Used to associate response to earlier PaidRequest
+    requestIdRef UInt128,
+    packet InterledgerPacket
 }
 
 PrepareRequest ::= SEQUENCE {
-  transferId UInt128,
-  amount UInt64,
-  condition UInt256,
-  expiresAt Timestamp,
-  packet InterledgerPacket,
-  -- Additional data for protocol extensibility
-  sideProtocolData SideProtocolData
+    -- Used to associate later response/fulfill/reject
+    -- MUST be non-zero and non-repeating
+    requestId UInt128,
+    amount UInt64,
+    condition UInt256,
+    expiresAt Timestamp,
+    packet InterledgerPacket
 }
 
 PrepareResponse ::= SEQUENCE {
-  -- Additional data for protocol extensibility
-  sideProtocolData SideProtocolData
+    -- Used to confirm such a PrepareRequest
+    requestIdRef UInt128
 }
 
 FulfillRequest ::= SEQUENCE {
-  transferId UInt128,
-  fulfillment UInt256,
-  -- Additional data for protocol extensibility
-  sideProtocolData SideProtocolData
+    -- Used to fulfill an earlier PrepareRequest
+    requestIdRef UInt128,
+    fulfillment UInt256
 }
 
 FulfillResponse ::= SEQUENCE {
-  -- Additional data for protocol extensibility
-  sideProtocolData SideProtocolData
+    -- Used to confirm such a FulfillRequest
+    requestIdRef UInt128
 }
 
 RejectRequest ::= SEQUENCE {
-  transferId UInt128,
-  rejectionReason InterledgerPacket,
-  -- Additional data for protocol extensibility
-  sideProtocolData SideProtocolData
+    -- Used to reject an earlier PrepareRequest
+    requestIdRef UInt128,
+    rejectionReason InterledgerPacket,
 }
 
 RejectResponse ::= SEQUENCE {
-  -- Additional data for protocol extensibility
-  sideProtocolData SideProtocolData
+    -- Used to confirm such a RejectRequest
+    requestIdRef UInt128,
 }
 
-TransferStateRequest ::= SEQUENCE {
-  transferId UInt128,
-  -- Additional data for protocol extensibility
-  sideProtocolData SideProtocolData
+RequestStateRequest ::= SEQUENCE {
+    -- Used to query the state of an earlier Prepare and possible Fulfill/Reject requests/responses
+    requestIdRef UInt128,
 }
 
-TransferStateResponse ::= SEQUENCE {
-  state CHOICE {
-    fulfillment UInt256,
-    rejectionReason InterledgerPacket,
-    prepared NULL,
-    nonExistent NULL
-  },
-  -- Additional data for protocol extensibility
-  sideProtocolData SideProtocolData
-}
-
-CustomRequest ::= SEQUENCE {
-  -- Additional data for protocol extensibility
-  sideProtocolData SideProtocolData
-}
-
-CustomResponse ::= SEQUENCE {
-  -- Additional data for protocol extensibility
-  sideProtocolData SideProtocolData
+RequestStateResponse ::= SEQUENCE {
+    -- Used to respond to such a RequestStateRequest
+    requestIdRef UInt128,
+    state CHOICE {
+      free NULL,
+      paid NULL,
+      prepared NULL,
+      fulfillment UInt256,
+      rejectionReason InterledgerPacket,
+      nonExistent NULL
+    },
 }
 
 CALL ::= CLASS {
@@ -107,28 +108,26 @@ CALL ::= CLASS {
 CallSet CALL ::= {
     -- All requests MUST use odd typeIds
     -- All responses MUST use even typeIds
-    {1 PacketRequest} |
-    {2 PacketResponse} |
-    {3 PrepareRequest} |
-    {4 PrepareResponse} |
-    {5 FulfillRequest} |
-    {6 FulfillResponse} |
-    {7 RejectRequest} |
-    {8 RejectResponse} |
-    {9 TransferStateRequest} |
-    {10 TransferStateResponse} |
-    {11 CustomRequest} |
-    {12 CustomResponse}
+    {1 FreeRequest} |
+    {2 FreeResponse} |
+    {3 PaidRequest} |
+    {4 PaidResponse} |
+    {5 PrepareRequest} |
+    {6 PrepareResponse} |
+    {7 FulfillRequest} |
+    {8 FulfillResponse} |
+    {9 RejectRequest} |
+    {10 RejectResponse} |
+    {11 RequestStateRequest} |
+    {12 RequestStateResponse}
 }
 
 LedgerLedgerLotocolPacket ::= SEQUENCE {
     -- One byte type ID
     type CALL.&typeId ({CallSet}),
-    -- Allow multiple accounts to be multiplexed on one connection
-    accountId UInt32,
-    -- Used to associate requests and corresponding responses
-    -- If requestId = 0, the server MUST not send a response
-    requestId UInt32,
+    -- Allow multiple from/to accounts to be multiplexed on one connection
+    fromId UInt32,
+    toId UInt32,
     -- Length-prefixed main data
     data CALL.&Type ({CallSet}{@type})
 }

--- a/asn1/LedgerLedgerLotocol.asn
+++ b/asn1/LedgerLedgerLotocol.asn
@@ -21,19 +21,19 @@ SideProtocolData ::= SEQUENCE OF SEQUENCE {
   protocolData OCTET STRING
 }
 
-MessageRequest ::= SEQUENCE {
+PacketRequest ::= SEQUENCE {
   packet InterledgerPacket,
   -- Additional data for protocol extensibility
   sideProtocolData SideProtocolData
 }
 
-MessageResponse ::= SEQUENCE {
+PacketResponse ::= SEQUENCE {
   packet InterledgerPacket,
   -- Additional data for protocol extensibility
   sideProtocolData SideProtocolData
 }
 
-TransferRequest ::= SEQUENCE {
+PrepareRequest ::= SEQUENCE {
   transferId UInt128,
   amount UInt64,
   condition UInt256,
@@ -43,7 +43,7 @@ TransferRequest ::= SEQUENCE {
   sideProtocolData SideProtocolData
 }
 
-TransferResponse ::= SEQUENCE {
+PrepareResponse ::= SEQUENCE {
   -- Additional data for protocol extensibility
   sideProtocolData SideProtocolData
 }
@@ -82,7 +82,7 @@ TransferStateResponse ::= SEQUENCE {
   state CHOICE {
     fulfillment UInt256,
     rejectionReason InterledgerPacket,
-    pending NULL,
+    prepared NULL,
     nonExistent NULL
   },
   -- Additional data for protocol extensibility
@@ -107,10 +107,10 @@ CALL ::= CLASS {
 CallSet CALL ::= {
     -- All requests MUST use odd typeIds
     -- All responses MUST use even typeIds
-    {1 MessageRequest} |
-    {2 MessageResponse} |
-    {3 TransferRequest} |
-    {4 TransferResponse} |
+    {1 PacketRequest} |
+    {2 PacketResponse} |
+    {3 PrepareRequest} |
+    {4 PrepareResponse} |
     {5 FulfillRequest} |
     {6 FulfillResponse} |
     {7 RejectRequest} |

--- a/asn1/LedgerLedgerLotocol.asn
+++ b/asn1/LedgerLedgerLotocol.asn
@@ -89,19 +89,6 @@ TransferStateResponse ::= SEQUENCE {
   sideProtocolData SideProtocolData
 }
 
-BalanceRequest ::= SEQUENCE {
-  -- Additional data for protocol extensibility
-  sideProtocolData SideProtocolData
-}
-
-BalanceResponse ::= SEQUENCE {
-  currentBalance VarInt,
-  minBalance VarInt,
-  maxBalance VarInt,
-  -- Additional data for protocol extensibility
-  sideProtocolData SideProtocolData
-}
-
 CustomRequest ::= SEQUENCE {
   -- Additional data for protocol extensibility
   sideProtocolData SideProtocolData
@@ -130,10 +117,8 @@ CallSet CALL ::= {
     {8 RejectResponse} |
     {9 TransferStateRequest} |
     {10 TransferStateResponse} |
-    {11 BalanceRequest} |
-    {12 BalanceResponse} |
-    {13 CustomRequest} |
-    {14 CustomResponse}
+    {11 CustomRequest} |
+    {12 CustomResponse}
 }
 
 LedgerLedgerLotocolPacket ::= SEQUENCE {

--- a/asn1/LedgerLedgerLotocol.asn
+++ b/asn1/LedgerLedgerLotocol.asn
@@ -1,0 +1,151 @@
+LedgerLedgerLotocol
+DEFINITIONS
+AUTOMATIC TAGS ::=
+BEGIN
+
+IMPORTS
+    UInt8,
+    UInt32,
+    UInt64,
+    UInt128,
+    UInt256
+    FROM GenericTypes
+
+    Address,
+    Timestamp
+    FROM InterledgerTypes
+;
+
+SideProtocolData ::= SEQUENCE OF SEQUENCE {
+  protocolName IA5String,
+  protocolData OCTET STRING
+}
+
+MessageRequest ::= SEQUENCE {
+  packet InterledgerPacket,
+  -- Additional data for protocol extensibility
+  sideProtocolData SideProtocolData
+}
+
+MessageResponse ::= SEQUENCE {
+  packet InterledgerPacket,
+  -- Additional data for protocol extensibility
+  sideProtocolData SideProtocolData
+}
+
+TransferRequest ::= SEQUENCE {
+  transferId UInt128,
+  amount UInt64,
+  condition UInt256,
+  expiresAt Timestamp,
+  packet InterledgerPacket,
+  -- Additional data for protocol extensibility
+  sideProtocolData SideProtocolData
+}
+
+TransferResponse ::= SEQUENCE {
+  -- Additional data for protocol extensibility
+  sideProtocolData SideProtocolData
+}
+
+FulfillRequest ::= SEQUENCE {
+  transferId UInt128,
+  fulfillment UInt256,
+  -- Additional data for protocol extensibility
+  sideProtocolData SideProtocolData
+}
+
+FulfillResponse ::= SEQUENCE {
+  -- Additional data for protocol extensibility
+  sideProtocolData SideProtocolData
+}
+
+RejectRequest ::= SEQUENCE {
+  transferId UInt128,
+  rejectionReason InterledgerPacket,
+  -- Additional data for protocol extensibility
+  sideProtocolData SideProtocolData
+}
+
+RejectResponse ::= SEQUENCE {
+  -- Additional data for protocol extensibility
+  sideProtocolData SideProtocolData
+}
+
+TransferStateRequest ::= SEQUENCE {
+  transferId UInt128,
+  -- Additional data for protocol extensibility
+  sideProtocolData SideProtocolData
+}
+
+TransferStateResponse ::= SEQUENCE {
+  state CHOICE {
+    fulfillment UInt256,
+    rejectionReason InterledgerPacket,
+    pending NULL,
+    nonExistent NULL
+  },
+  -- Additional data for protocol extensibility
+  sideProtocolData SideProtocolData
+}
+
+BalanceRequest ::= SEQUENCE {
+  -- Additional data for protocol extensibility
+  sideProtocolData SideProtocolData
+}
+
+BalanceResponse ::= SEQUENCE {
+  currentBalance VarInt,
+  minBalance VarInt,
+  maxBalance VarInt,
+  -- Additional data for protocol extensibility
+  sideProtocolData SideProtocolData
+}
+
+CustomRequest ::= SEQUENCE {
+  -- Additional data for protocol extensibility
+  sideProtocolData SideProtocolData
+}
+
+CustomResponse ::= SEQUENCE {
+  -- Additional data for protocol extensibility
+  sideProtocolData SideProtocolData
+}
+
+CALL ::= CLASS {
+    &typeId UInt8 UNIQUE,
+    &Type
+} WITH SYNTAX {&typeId &Type}
+
+CallSet CALL ::= {
+    -- All requests MUST use odd typeIds
+    -- All responses MUST use even typeIds
+    {1 MessageRequest} |
+    {2 MessageResponse} |
+    {3 TransferRequest} |
+    {4 TransferResponse} |
+    {5 FulfillRequest} |
+    {6 FulfillResponse} |
+    {7 RejectRequest} |
+    {8 RejectResponse} |
+    {9 TransferStateRequest} |
+    {10 TransferStateResponse} |
+    {11 BalanceRequest} |
+    {12 BalanceResponse} |
+    {13 CustomRequest} |
+    {14 CustomResponse}
+}
+
+LedgerLedgerLotocolPacket ::= SEQUENCE {
+    -- One byte type ID
+    type CALL.&typeId ({CallSet}),
+    -- Allow multiple accounts to be multiplexed on one connection
+    accountId UInt32,
+    -- Used to associate requests and corresponding responses
+    -- If requestId = 0, the server MUST not send a response
+    requestId UInt32,
+    -- Length-prefixed main data
+    data CALL.&Type ({CallSet}{@type})
+}
+
+END


### PR DESCRIPTION
If we redefine LLL as free/paid/conditional request/response protocol, where the payload is always an ILP packet, then it makes sense to move `CustomMessage` and `SideProtocolData` to the payload (ILP packet) level.

* rename PacketRequest to FreeRequest
* add PaidRequest
* add a 'Custom' ILP packet
* remove SideProtocolData and instead use 'Custom' inside 'FreePacket' 
* get rid of transactionId in PrepareRequest in favor of requestId