### PR TITLE
Add message layer 

### DIFF
--- a/asn1/GenericMessage.asn
+++ b/asn1/GenericMessage.asn
@@ -1,0 +1,79 @@
+GenericMessage
+DEFINITIONS
+AUTOMATIC TAGS ::=
+BEGIN
+
+IMPORTS
+    UInt8
+    UInt128
+    UInt256
+    FROM GenericTypes
+
+    Timestamp
+    FROM InterledgerTypes
+;
+
+SideProtocolData ::= SEQUENCE OF SEQUENCE {
+  protocolName IA5String,
+  protocolData OCTET STRING
+}
+
+AckResponseMessage ::= SEQUENCE {
+  -- The messageId of the request
+  correlationId UInt32,
+}
+
+ErrorResponseMessage ::= SEQUENCE {
+  -- The messageId of the request
+  correlationId UInt32,
+  -- The error data (Could define a struct here for messaging errors?)
+  error OCTET STRING (SIZE (0..8192))
+
+  sideProtocolData SideProtocolData
+}
+
+InterledgerRequestMessage ::= SEQUENCE {
+  packet InterledgerPacket,
+  sideProtocolData SideProtocolData
+}
+
+InterledgerResponseMessage ::= SEQUENCE {
+  -- The messageId of the request
+  correlationId UInt32,
+  packet InterledgerPacket,
+  sideProtocolData SideProtocolData
+}
+
+GenericRequestMessage ::= SEQUENCE {
+  sideProtocolData SideProtocolData
+}
+
+GenericResponseMessage ::= SEQUENCE {
+  correlationId UInt32,
+  sideProtocolData SideProtocolData
+}
+
+MESSAGE ::= CLASS {
+    &typeId UInt8 UNIQUE,
+    &Type
+} WITH SYNTAX {&typeId &Type}
+
+MessageSet MESSAGE ::= {
+    {1 AckResponseMessage} |
+    {2 ErrorResponseMessage} |
+    {3 InterledgerRequestMessage} |
+    {4 InterledgerResponseMessage} |
+    {5 GenericRequestMessage} |
+    {6 GenericResponseMessage} 
+}
+
+MessagePacket ::= SEQUENCE {
+    -- Unique identifier for the message
+    messageId UInt32,
+    -- One byte type ID
+    type MESSAGE.&typeId ({MessageSet}),
+    -- Length-prefixed message data
+    data MESSAGE.&Type ({MessageSet}{@type})
+}
+
+END

--- a/asn1/GenericPacket.asn
+++ b/asn1/GenericPacket.asn
@@ -8,16 +8,18 @@ IMPORTS
     VarBytes
     FROM GenericTypes
 
-    InterledgerProtocolPayment,
-    InterledgerProtocolError
-    FROM InterledgerProtocol
+    TransferRequest,
+    SuccessfulTransferResponse,
+    FailedTransferResponse
+    FROM InterledgerTransferProtocol
 
     QuoteLiquidityRequest,
     QuoteLiquidityResponse,
     QuoteBySourceAmountRequest,
     QuoteBySourceAmountResponse,
     QuoteByDestinationAmountRequest,
-    QuoteByDestinationAmountResponse
+    QuoteByDestinationAmountResponse,
+    FailedQuoteResponse
     FROM InterledgerQuotingProtocol
 ;
 
@@ -27,14 +29,16 @@ PACKET ::= CLASS {
 } WITH SYNTAX {&typeId &Type}
 
 PacketSet PACKET ::= {
-    {1 InterledgerProtocolPayment} |
-    {2 QuoteLiquidityRequest} |
-    {3 QuoteLiquidityResponse} |
-    {4 QuoteBySourceAmountRequest} |
-    {5 QuoteBySourceAmountResponse} |
-    {6 QuoteByDestinationAmountRequest} |
-    {7 QuoteByDestinationAmountResponse} |
-    {8 InterledgerProtocolError}
+    {1 TransferRequest} |
+    {2 SuccessfulTransferResponse} |
+    {3 FailedTransferResponse} |
+    {4 QuoteLiquidityRequest} |
+    {5 QuoteLiquidityResponse} |
+    {6 QuoteBySourceAmountRequest} |
+    {7 QuoteBySourceAmountResponse} |
+    {8 QuoteByDestinationAmountRequest} |
+    {9 QuoteByDestinationAmountResponse} |
+    {10 FailedQuoteResponse}
 }
 
 InterledgerPacket ::= SEQUENCE {

--- a/asn1/InterledgerPaymentRequest.asn
+++ b/asn1/InterledgerPaymentRequest.asn
@@ -1,4 +1,4 @@
-InterledgerProtocol
+InterledgerPaymentRequest
 DEFINITIONS
 AUTOMATIC TAGS ::=
 BEGIN

--- a/asn1/InterledgerQuotingProtocol.asn
+++ b/asn1/InterledgerQuotingProtocol.asn
@@ -1,4 +1,5 @@
-InterledgerQuotingProtocol DEFINITIONS AUTOMATIC TAGS ::=
+InterledgerQuotingProtocol 
+DEFINITIONS AUTOMATIC TAGS ::=
 BEGIN
 
 IMPORTS
@@ -10,12 +11,16 @@ IMPORTS
     Timestamp,
     LiquidityCurve
     FROM InterledgerTypes
+
+    InterledgerProtocolError
+    FROM InterledgerProtocol
 ;
 
 -- Request to receive liquidity information between the current ledger and the
 -- destination account. This information is sufficient to locally quote any
 -- amount until the curve expires.
 QuoteLiquidityRequest ::= SEQUENCE {
+    quoteId UInt128,
     destinationAccount Address,
     -- How much time the receiver needs to fulfill the payment (in milliseconds)
     destinationHoldDuration UInt32,
@@ -27,6 +32,7 @@ QuoteLiquidityRequest ::= SEQUENCE {
 }
 
 QuoteLiquidityResponse ::= SEQUENCE {
+    quoteId UInt128,
     -- Curve describing the liquidity (relationship between input and output
     -- amounts) for the quoted route
     liquidity LiquidityCurve,
@@ -53,6 +59,7 @@ QuoteLiquidityResponse ::= SEQUENCE {
 
 -- Quoting with a specified source amount to determine destination amount
 QuoteBySourceAmountRequest ::= SEQUENCE {
+    quoteId UInt128,
     destinationAccount Address,
     sourceAmount UInt64,
     -- How much time the receiver needs to fulfill the payment (in milliseconds)
@@ -65,6 +72,7 @@ QuoteBySourceAmountRequest ::= SEQUENCE {
 }
 
 QuoteBySourceAmountResponse ::= SEQUENCE {
+    quoteId UInt128,
     -- Amount that will arrive at the receiver
     destinationAmount UInt64,
     -- How long the sender should put money on hold (in milliseconds)
@@ -78,6 +86,7 @@ QuoteBySourceAmountResponse ::= SEQUENCE {
 
 -- Quoting with a specified destination amount to determine source amount
 QuoteByDestinationAmountRequest ::= SEQUENCE {
+    quoteId UInt128,
     destinationAccount Address,
     destinationAmount UInt64,
     -- How much time the receiver needs to fulfill the payment (in milliseconds)
@@ -90,11 +99,22 @@ QuoteByDestinationAmountRequest ::= SEQUENCE {
 }
 
 QuoteByDestinationAmountResponse ::= SEQUENCE {
+    quoteId UInt128,
     -- Amount the sender needs to send based on the requested destination amount
     sourceAmount UInt64,
     -- How long the sender should put money on hold (in milliseconds)
     sourceHoldDuration UInt32,
 
+    -- Enable ASN.1 Extensibility
+    extensions SEQUENCE {
+        ...
+    }
+}
+
+FailedQuoteResponse ::= SEQUENCE {
+    quoteId UInt128,
+    error InterledgerProtocolError
+    
     -- Enable ASN.1 Extensibility
     extensions SEQUENCE {
         ...

--- a/asn1/InterledgerTransferProtocol.asn
+++ b/asn1/InterledgerTransferProtocol.asn
@@ -1,0 +1,38 @@
+InterledgerTransferProtocol
+DEFINITIONS
+AUTOMATIC TAGS ::=
+BEGIN
+
+IMPORTS
+    UInt64,
+    UInt128,
+    UInt256
+    FROM GenericTypes
+
+    Timestamp
+    FROM InterledgerTypes
+    
+    InterledgerProtocolPayment,
+    InterledgerProtocolError
+    FROM InterledgerProtocol
+;
+
+TransferRequest ::= SEQUENCE {
+  transferId UInt128,
+  amount UInt64,
+  executionCondition UInt256,
+  expiresAt Timestamp,
+  packet InterledgerProtocolPayment,
+}
+
+SuccessfulTransferResponse ::= SEQUENCE {
+  transferId UInt128,
+  fulfillment UInt256
+}
+
+FailedTransferResponse ::= SEQUENCE {
+  transferId UInt128,
+  error InterledgerProtocolError
+}
+
+END


### PR DESCRIPTION
Added a generic messaging layer to carry bi-lateral messages between nodes (GenericMessage.asn).

Modify logical request/response layer (GenericPacket.asn) to include transfers (InterledgerTransferProtocol.asn) and move payments up to Interledger layer (InterledgerProtocol.asn) which has only payments and error packets.

Layers are now clearly defined and encapsulated with the ledger layer having two sub-layers, a logical layer and a messaging layer.

```
Application
Transport
 - End-to-end transport specific (e.g. PSK)
Interledger
 - ILP Payment Packet/ILP Error
Ledger
 - Logical Transfer/Quote
 - Message
```