### PR TITLE
fix: align CustomRequest with Ack

### DIFF
--- a/asn1/CommonLedgerProtocol.asn
+++ b/asn1/CommonLedgerProtocol.asn
@@ -75,9 +75,7 @@ Message ::= SEQUENCE {
   sideProtocolData SideProtocolData
 }
 
-CustomRequest ::= SEQUENCE {
-  sideProtocolData SideProtocolData
-}
+CustomRequest ::= SideProtocolData
 
 CALL ::= CLASS {
     &typeId UInt8 UNIQUE,

--- a/asn1/CommonLedgerProtocol.asn
+++ b/asn1/CommonLedgerProtocol.asn
@@ -96,7 +96,6 @@ CommonLedgerProtocolPacket ::= SEQUENCE {
     -- One byte type ID
     type CALL.&typeId ({CallSet}),
     -- Used to associate requests and corresponding responses
-    -- If requestId = 0, the server MUST not send a response
     requestId UInt32,
     -- Length-prefixed main data
     data CALL.&Type ({CallSet}{@type})

--- a/asn1/InterledgerPaymentRequest.asn
+++ b/asn1/InterledgerPaymentRequest.asn
@@ -14,7 +14,7 @@ InterledgerPaymentRequest ::= SEQUENCE {
     version UInt8,
     -- Cryptographic condition
     condition UInt256,
-    -- ILP Payment Packet
+    -- InterledgerProtocolPayment
     packet OCTET STRING
 }
 


### PR DESCRIPTION
Same change for CustomRequest, as already merged for Ack.
Since the typeId is already in the CLPP, you can go straight to the CustomRequest's only data field.