### PR TITLE
fix: ILP Packet -> InterledgerProtocolPayment

### DIFF
--- a/0003-interledger-protocol/0003-interledger-protocol.md
+++ b/0003-interledger-protocol/0003-interledger-protocol.md
@@ -1,6 +1,6 @@
 ---
 title: The Interledger Protocol (ILP)
-draft: 3
+draft: 4
 ---
 # Interledger Protocol (ILP)
 
@@ -156,9 +156,34 @@ Here is a summary of the fields in the ILP payment packet format:
 
 | Field | Type | Short Description |
 |:--|:--|:--|
+| type | UInt8 | Always `1`, indicates that this ILP packet is an ILP Payment Packet (type 1) |
+| length | Length Determinant | Indicates how many bytes the rest of the packet has |
 | amount | UInt64 | Amount the destination account should receive, denominated in the asset of the destination ledger |
 | account | Address | Address corresponding to the destination account |
 | data | OCTET STRING | Transport layer data attached to the payment |
+| extensions | Length Determinant | Always `0`
+
+#### Example
+
+| Type | Length, 8+(1+14)+(1+3)+1=28 | Amount (123,000,000) ... |
+|:--|:--|:--|
+| 1    |  28    | 0 0 0 0 7 84 |
+
+
+| .. Amount (123,000,000) | Length | Adddress ... ('g.us.') |
+|:--|:--|:--|
+| 212 192 | 14     | 103 46 117 115 46 |
+
+| ... Adddress ('nexus.bo') ... |
+|:--|
+| 110 101 120 117 115 46 98 111 |
+
+| ... Adddress ('b') | length | data    | extensions |
+|:--|:--|:--|:--|
+| 98 | 3      | 4 16 65 | 0          |
+
+
+Let's look more closely at the three important fields: `amount`, `address`, and `data`.
 
 #### amount
 

--- a/0004-ledger-plugin-interface/0004-ledger-plugin-interface.md
+++ b/0004-ledger-plugin-interface/0004-ledger-plugin-interface.md
@@ -1,6 +1,6 @@
 ---
 title: The Javascript Ledger Plugin Interface
-draft: 7
+draft: 8
 ---
 # Javascript Ledger Plugin Interface
 

--- a/0004-ledger-plugin-interface/0004-ledger-plugin-interface.md
+++ b/0004-ledger-plugin-interface/0004-ledger-plugin-interface.md
@@ -521,7 +521,7 @@ An integer amount, represented as a string of base-ten digits. MUST be `>= 0` an
 #### Transfer#ilp
 <code>**ilp**:String</code>
 
-An [ILP packet](../0003-interledger-protocol/), denoting the payment's final destination.
+An [ILP packet](https://interledger.org/rfcs/0003-interledger-protocol/draft-4.html#specification), denoting the payment's final destination.
 
 If the `ilp` data is too large, the ledger plugin MUST reject with a `MaximumIlpDataSizeExceededError`.
 
@@ -612,7 +612,8 @@ The ILP Prefix of the ledger being used to transfer the message.
 #### Message#ilp
 <code>**ilp**:String</code>
 
-An [ILP packet](../0003-interledger-protocol/), used for communication among ledger participants. Include either this field, or the `custom` field, or both.
+An [ILP packet](https://interledger.org/rfcs/0003-interledger-protocol/draft-4.html#specification), used for communication among ledger participants.
+Include either this field, or the `custom` field, or both.
 
 If the `ilp` data is too large, the ledger plugin MUST reject with a `MaximumIlpDataSizeExceededError`.
 

--- a/0008-interledger-quoting-protocol/0008-interledger-quoting-protocol.md
+++ b/0008-interledger-quoting-protocol/0008-interledger-quoting-protocol.md
@@ -37,7 +37,7 @@ In a multiple-hop payment, there are multiple connectors, each of which creates 
 
 Quotes are sent through a request/response mechanism exposed by the ledger plugins or ledger layer.
 
-A quote request's `ilp` property must be an `IlqpLiquidityRequest`, `QuoteBySourceRequest`, or `QuoteByDestinationRequest`. The response's `ilp` property must be an `IlqpLiquidityResponse`, `QuoteBySourceResponse`, or `QuoteByDestinationResponse` respectively. If an error occurs during quoting, `ilp` will be a [`IlpError`](../0003-interledger-protocol/0003-interledger-protocol.md#ilp-error-format) instead.
+A quote request's `ilp` property must be a `QuoteLiquidityRequest`, `QuoteBySourceRequest`, or `QuoteByDestinationRequest`. The response's `ilp` property must be a `QuoteLiquidityResponse`, `QuoteBySourceResponse`, or `QuoteByDestinationResponse` respectively. If an error occurs during quoting, `ilp` will be a [`IlpError`](../0003-interledger-protocol/0003-interledger-protocol.md#ilp-error-format) instead.
 
 ## ILQP Packets
 

--- a/0008-interledger-quoting-protocol/0008-interledger-quoting-protocol.md
+++ b/0008-interledger-quoting-protocol/0008-interledger-quoting-protocol.md
@@ -1,6 +1,6 @@
 ---
 title: The Interledger Quoting Protocol (ILQP)
-draft: 2
+draft: 3
 ---
 # Interledger Quoting Protocol (ILQP)
 
@@ -37,61 +37,79 @@ In a multiple-hop payment, there are multiple connectors, each of which creates 
 
 Quotes are sent through a request/response mechanism exposed by the ledger plugins or ledger layer.
 
-A quote request's `ilp` property must be an `IlqpLiquidityRequest`, `IlqpBySourceRequest`, or `IlqpByDestinationRequest`. The response's `ilp` property must be an `IlqpLiquidityResponse`, `IlqpBySourceResponse`, or `IlqpByDestinationResponse` respectively. If an error occurs during quoting, `ilp` will be a [`IlpError`](../0003-interledger-protocol/0003-interledger-protocol.md#ilp-error-format) instead.
+A quote request's `ilp` property must be an `IlqpLiquidityRequest`, `QuoteBySourceRequest`, or `QuoteByDestinationRequest`. The response's `ilp` property must be an `IlqpLiquidityResponse`, `QuoteBySourceResponse`, or `QuoteByDestinationResponse` respectively. If an error occurs during quoting, `ilp` will be a [`IlpError`](../0003-interledger-protocol/0003-interledger-protocol.md#ilp-error-format) instead.
 
 ## ILQP Packets
 
 See [interledgerjs/ilp-packet](https://github.com/interledgerjs/ilp-packet/) for an example implementation of a packet serializer/deserializer.
 
-### IlqpLiquidityRequest
+### QuoteLiquidityRequest
 
 | Field | Type | Short Description |
 |:--|:--|:--|
-| destinationAccount | Address | Address corresponding to the destination account |
+| type | Byte | Always `2` |
+| length | Length Determinant | One or more bytes, indicating how many bytes follow in the rest of the packet |
+| destinationAccount | Length-prefixed String | Address corresponding to the destination account |
 | destinationHoldDuration | UInt32 | How much time the receiver needs to fulfill the payment (in milliseconds) |
+| extensions | Length Determinant | Always `0` |
 
-### IlqpLiquidityResponse
+### QuoteLiquidityResponse
 
 | Field | Type | Short Description |
 |:--|:--|:--|
+| type | Byte | Always `3` |
+| length | Length Determinant | One or more bytes, indicating how many bytes follow in the rest of the packet |
 | liquidity | LiquidityCurve | Curve describing the liquidity for the quoted route |
-| appliesToPrefix | Address | Common prefix of all addresses for which this liquidity curve applies. |
+| appliesToPrefix | Length-prefixed String | Common prefix of all addresses for which this liquidity curve applies. |
 | sourceHoldDuration | UInt32 | How long the sender should put the money on hold (in milliseconds) |
 | expiresAt | Timestamp | Maximum time where the connector expects to be able to honor this liquidity curve. This MUST be expressed in the UTC + 0 (Z) timezone. |
+| extensions | Length Determinant | Always `0` |
 
 `LiquidityCurve` is encoded as a `SEQUENCE OF SEQUENCE { x UInt64, y UInt64 }`. This is a binary format, so for example the curve `[ [0, 0], [10, 265] ]` is equivalent to the base64-encoded string `"AAAAAAAAAAAAAAAAAAAAAAAAAAAKAAAAAAAAAAkBAAA="`.
 
 See [interledgerjs/ilp-routing.LiquidityCurve](https://github.com/interledgerjs/ilp-routing/blob/master/src/lib/liquidity-curve.js) for an example implementation of a LiquidityCurve serializer/deserializer.
 
-### IlqpBySourceRequest
+### QuoteBySourceRequest
 
 | Field | Type | Short Description |
 |:--|:--|:--|
-| destinationAccount | Address | Address corresponding to the destination account |
+| type | Byte | Always `4` |
+| length | Length Determinant | One or more bytes, indicating how many bytes follow in the rest of the packet |
+| destinationAccount | Length-prefixed String | Length-prefixed address corresponding to the destination account |
 | sourceAmount | UInt64 | Amount the sender needs to send, denominated in the asset of the source ledger |
 | destinationHoldDuration | UInt32 | How much time the receiver needs to fulfill the payment (in milliseconds) |
+| extensions | Length Determinant | Always `0` |
 
-### IlqpBySourceResponse
+### QuoteBySourceResponse
 
 | Field | Type | Short Description |
 |:--|:--|:--|
+| type | Byte | Always `5` |
+| length | Length Determinant | One or more bytes, indicating how many bytes follow in the rest of the packet |
 | destinationAmount | UInt64 | Amount that will arrive at the receiver |
 | sourceHoldDuration | UInt32 | How long the sender should put money on hold (in milliseconds) |
+| extensions | Length Determinant | Always `0` |
 
-### IlqpByDestinationRequest
+### QuoteByDestinationRequest
 
 | Field | Type | Short Description |
 |:--|:--|:--|
-| destinationAccount | Address | Address corresponding to the destination account |
+| type | Byte | Always `6` |
+| length | Length Determinant | One or more bytes, indicating how many bytes follow in the rest of the packet |
+| destinationAccount | Length-prefixed String | Length-prefixed address corresponding to the destination account |
 | destinationAmount | UInt64 | Amount that will arrive at the receiver |
 | destinationHoldDuration | UInt32 | How much time the receiver needs to fulfill the payment (in milliseconds) |
+| extensions | Length Determinant | Always `0` |
 
-### IlqpByDestinationResponse
+### QuoteByDestinationResponse
 
 | Field | Type | Short Description |
 |:--|:--|:--|
+| type | Byte | Always `7` |
+| length | Length Determinant | One or more bytes, indicating how many bytes follow in the rest of the packet |
 | sourceAmount | UInt64 | Amount the sender needs to send, denominated in the asset of the source ledger |
 | sourceHoldDuration | UInt32 | How long the sender should put money on hold (in milliseconds) |
+| extensions | Length Determinant | Always `0` |
 
 ## Next Steps
 

--- a/0011-interledger-payment-request/0011-interledger-payment-request.md
+++ b/0011-interledger-payment-request/0011-interledger-payment-request.md
@@ -1,6 +1,6 @@
 ---
 title: Interledger Payment Requests (IPR)
-draft: 1
+draft: 2
 ---
 # Interledger Payment Request (IPR)
 
@@ -83,7 +83,7 @@ IPR version. This document specifies version 2.
 
     OCTET STRING (SIZE(0..65535))
 
-The [ILP Payment Packet](../0003-interledger-protocol/0003-interledger-protocol.md#specification).
+The [ILP Payment Packet](https://interledger.org/rfcs/0003-interledger-protocol/draft-3.html#specification).
 
 In IPR the sender only uses the `account` and `amount` from the ILP packet and MUST treat the `data` as opaque.
 

--- a/0016-pre-shared-key/0016-pre-shared-key.md
+++ b/0016-pre-shared-key/0016-pre-shared-key.md
@@ -1,10 +1,10 @@
 ---
 title: The Pre-Shared Key Transport Protocol (PSK)
-draft: 2
+draft: 3
 ---
 # Pre-Shared Key Transport Protocol (PSK)
 
-The Pre-Shared Key (PSK) protocol is an end-to-end transport protocol, used by the sender and receiver of an ILP payment to decide on a condition and fulfillment for a payment. By default, the protocol also encrypts any additional data sent along with the payment, using [AES-256-GCM](https://en.wikipedia.org/wiki/Galois/Counter_Mode). The full ILP payment is authenticated through an [HMAC-SHA-256](https://en.wikipedia.org/wiki/Hash-based_message_authentication_code) which is used to generate the fulfillment of a PSK payment. The entirety of the PSK data, including public headers, encrypted private headers, and encrypted private data, is encoded into an octet-stream that forms the data portion of the [ILP Packet](https://github.com/interledger/rfcs/blob/master/0003-interledger-protocol/0003-interledger-protocol.md). The PSK data is authenticated via AES-256-GCM in addition to the HMAC-SHA-256 which authenticates the full ILP payment.
+The Pre-Shared Key (PSK) protocol is an end-to-end transport protocol, used by the sender and receiver of an ILP payment to decide on a condition and fulfillment for a payment. By default, the protocol also encrypts any additional data sent along with the payment, using [AES-256-GCM](https://en.wikipedia.org/wiki/Galois/Counter_Mode). The full ILP payment is authenticated through an [HMAC-SHA-256](https://en.wikipedia.org/wiki/Hash-based_message_authentication_code) which is used to generate the fulfillment of a PSK payment. The entirety of the PSK data, including public headers, encrypted private headers, and encrypted private data, is encoded into an octet-stream that forms the data portion of the [ILP Packet](https://interledger.org/rfcs/0003-interledger-protocol/draft-4.html#specification). The PSK data is authenticated via AES-256-GCM in addition to the HMAC-SHA-256 which authenticates the full ILP payment.
 
 Pseudocode for this protocol can be read [at the bottom of this spec](#pseudocode).
 

--- a/asn1/InterledgerPacket.asn
+++ b/asn1/InterledgerPacket.asn
@@ -8,16 +8,16 @@ IMPORTS
     VarBytes
     FROM GenericTypes
 
-    InterledgerProtocolPayment,
-    InterledgerProtocolError
+    InterledgerProtocolPaymentData,
+    InterledgerProtocolErrorData
     FROM InterledgerProtocol
 
-    QuoteLiquidityRequest,
-    QuoteLiquidityResponse,
-    QuoteBySourceAmountRequest,
-    QuoteBySourceAmountResponse,
-    QuoteByDestinationAmountRequest,
-    QuoteByDestinationAmountResponse
+    QuoteLiquidityRequestData,
+    QuoteLiquidityResponseData,
+    QuoteBySourceAmountRequestData,
+    QuoteBySourceAmountResponseData,
+    QuoteByDestinationAmountRequestData,
+    QuoteByDestinationAmountResponseData
     FROM InterledgerQuotingProtocol
 ;
 
@@ -27,14 +27,14 @@ PACKET ::= CLASS {
 } WITH SYNTAX {&typeId &Type}
 
 PacketSet PACKET ::= {
-    {1 InterledgerProtocolPayment} |
-    {2 QuoteLiquidityRequest} |
-    {3 QuoteLiquidityResponse} |
-    {4 QuoteBySourceAmountRequest} |
-    {5 QuoteBySourceAmountResponse} |
-    {6 QuoteByDestinationAmountRequest} |
-    {7 QuoteByDestinationAmountResponse} |
-    {8 InterledgerProtocolError}
+    {1 InterledgerProtocolPaymentData} |
+    {2 QuoteLiquidityRequestData} |
+    {3 QuoteLiquidityResponseData} |
+    {4 QuoteBySourceAmountRequestData} |
+    {5 QuoteBySourceAmountResponseData} |
+    {6 QuoteByDestinationAmountRequestData} |
+    {7 QuoteByDestinationAmountResponseData} |
+    {8 InterledgerProtocolErrorData}
 }
 
 InterledgerPacket ::= SEQUENCE {

--- a/asn1/InterledgerProtocol.asn
+++ b/asn1/InterledgerProtocol.asn
@@ -12,7 +12,7 @@ IMPORTS
     FROM InterledgerTypes
 ;
 
-InterledgerProtocolPayment ::= SEQUENCE {
+InterledgerProtocolPaymentData ::= SEQUENCE {
     -- Amount which must be received at the destination
     amount UInt64,
     -- Destination ILP Address
@@ -25,7 +25,7 @@ InterledgerProtocolPayment ::= SEQUENCE {
     }
 }
 
-InterledgerProtocolError ::= SEQUENCE {
+InterledgerProtocolErrorData ::= SEQUENCE {
     -- Standardized error code
     code IA5String (SIZE (3)),
     -- Corresponding error name

--- a/asn1/InterledgerQuotingProtocol.asn
+++ b/asn1/InterledgerQuotingProtocol.asn
@@ -17,7 +17,7 @@ IMPORTS
 -- Request to receive liquidity information between the current ledger and the
 -- destination account. This information is sufficient to locally quote any
 -- amount until the curve expires.
-QuoteLiquidityRequest ::= SEQUENCE {
+QuoteLiquidityRequestData ::= SEQUENCE {
     destinationAccount Address,
     -- How much time the receiver needs to fulfill the payment (in milliseconds)
     destinationHoldDuration UInt32,
@@ -28,7 +28,7 @@ QuoteLiquidityRequest ::= SEQUENCE {
     }
 }
 
-QuoteLiquidityResponse ::= SEQUENCE {
+QuoteLiquidityResponseData ::= SEQUENCE {
     -- Curve describing the liquidity (relationship between input and output
     -- amounts) for the quoted route
     liquidity LiquidityCurve,
@@ -54,7 +54,7 @@ QuoteLiquidityResponse ::= SEQUENCE {
 }
 
 -- Quoting with a specified source amount to determine destination amount
-QuoteBySourceAmountRequest ::= SEQUENCE {
+QuoteBySourceAmountRequestData ::= SEQUENCE {
     destinationAccount Address,
     sourceAmount UInt64,
     -- How much time the receiver needs to fulfill the payment (in milliseconds)
@@ -66,7 +66,7 @@ QuoteBySourceAmountRequest ::= SEQUENCE {
     }
 }
 
-QuoteBySourceAmountResponse ::= SEQUENCE {
+QuoteBySourceAmountResponseData ::= SEQUENCE {
     -- Amount that will arrive at the receiver
     destinationAmount UInt64,
     -- How long the sender should put money on hold (in milliseconds)
@@ -79,7 +79,7 @@ QuoteBySourceAmountResponse ::= SEQUENCE {
 }
 
 -- Quoting with a specified destination amount to determine source amount
-QuoteByDestinationAmountRequest ::= SEQUENCE {
+QuoteByDestinationAmountRequestData ::= SEQUENCE {
     destinationAccount Address,
     destinationAmount UInt64,
     -- How much time the receiver needs to fulfill the payment (in milliseconds)
@@ -91,7 +91,7 @@ QuoteByDestinationAmountRequest ::= SEQUENCE {
     }
 }
 
-QuoteByDestinationAmountResponse ::= SEQUENCE {
+QuoteByDestinationAmountResponseData ::= SEQUENCE {
     -- Amount the sender needs to send based on the requested destination amount
     sourceAmount UInt64,
     -- How long the sender should put money on hold (in milliseconds)


### PR DESCRIPTION
I tried to push the abbreviation 'ipp' but it didn't really seem to stick.

In any case, the current situation where 'ILP Packet' can be either https://github.com/interledger/rfcs/blob/master/asn1/InterledgerProtocol.asn#L15 by itself, or wrapped inside https://github.com/interledger/rfcs/blob/master/asn1/GenericPacket.asn#L40 is way too confusing, and is more or less guaranteed to lead to bugs where people try to parse it with/without the wrapper when the opposite was intended.