### PR TITLE
docs(0004): add plugin InsufficientBalanceError

### DIFF
--- a/0004-ledger-plugin-interface/0004-ledger-plugin-interface.md
+++ b/0004-ledger-plugin-interface/0004-ledger-plugin-interface.md
@@ -1,6 +1,6 @@
 ---
 title: The Javascript Ledger Plugin Interface
-draft: 3
+draft: 4
 ---
 # Javascript Ledger Plugin Interface
 
@@ -67,6 +67,7 @@ This spec depends on the [ILP spec](../0003-interledger-protocol/).
 | [**AlreadyFulfilledError**]() | A requested transfer has already been fulfilled and cannot be modified |
 | [**TransferNotConditionalError**]() | A requested transfer is not conditional and cannot be rejected/fulfilled/etc. |
 | [**NotAcceptedError**]() | An operation has been rejected due to ledger-side logic |
+| [**InsufficientBalanceError**]() | An operation has been rejected because the source balance isn't high enough |
 | [**NoSubscriptionsError**]() | A transfer or message cannot be delivered because there are no active websockets |
 | [**RequestHandlerAlreadyRegisteredError**]() | The current request handler callback must be unset before a new one can be registered |
 
@@ -221,8 +222,7 @@ are required.
 **`Promise.<null>`** A promise which resolves when the transfer has been submitted (but not necessarily accepted.)
 
 Rejects with `InvalidFieldsError` if required fields are missing from the transfer or malformed. Rejects with `DuplicateIdError` if a transfer with
-the given ID and different already exists. Rejects with `NotAcceptedError` if the transfer is rejected by the ledger due to insufficient balance or
-a nonexistant destination account.
+the given ID and different already exists. Rejects with `InsufficientBalanceError` if the transfer is rejected due to the source balance being too low. Rejects with `NotAcceptedError` if the transfer is otherwise rejected by the ledger (e.g. due to a nonexistant destination account).
 
 ###### Example
 ```js

--- a/0004-ledger-plugin-interface/0004-ledger-plugin-interface.md
+++ b/0004-ledger-plugin-interface/0004-ledger-plugin-interface.md
@@ -68,6 +68,7 @@ This spec depends on the [ILP spec](../0003-interledger-protocol/).
 | [**TransferNotConditionalError**]() | A requested transfer is not conditional and cannot be rejected/fulfilled/etc. |
 | [**NotAcceptedError**]() | An operation has been rejected due to ledger-side logic |
 | [**InsufficientBalanceError**]() | An operation has been rejected because the source balance isn't high enough |
+| [**AccountNotFoundError**]() | An operation has been rejected because the account does not exist |
 | [**NoSubscriptionsError**]() | A transfer or message cannot be delivered because there are no active websockets |
 | [**RequestHandlerAlreadyRegisteredError**]() | The current request handler callback must be unset before a new one can be registered |
 
@@ -222,7 +223,7 @@ are required.
 **`Promise.<null>`** A promise which resolves when the transfer has been submitted (but not necessarily accepted.)
 
 Rejects with `InvalidFieldsError` if required fields are missing from the transfer or malformed. Rejects with `DuplicateIdError` if a transfer with
-the given ID and different already exists. Rejects with `InsufficientBalanceError` if the transfer is rejected due to the source balance being too low. Rejects with `NotAcceptedError` if the transfer is otherwise rejected by the ledger (e.g. due to a nonexistant destination account).
+the given ID and different already exists. Rejects with `InsufficientBalanceError` if the transfer is rejected due to the source balance being too low. Rejects with `AccountNotFoundError` if the destination account does not exist. Rejects with `NotAcceptedError` if the transfer is otherwise rejected by the ledger.
 
 ###### Example
 ```js


### PR DESCRIPTION
Related to https://github.com/interledgerjs/ilp-connector/pull/390

`NotAcceptedError` is too general for the connector to accurately generate a `T04: Insufficient Liquidity` ILP error.