### PR TITLE
docs(3): add Payment Too Large error

### DIFF
--- a/0003-interledger-protocol/0003-interledger-protocol.md
+++ b/0003-interledger-protocol/0003-interledger-protocol.md
@@ -265,11 +265,9 @@ Date and time when the error was initially emitted. This MUST be expressed in th
 
     OCTET STRING (SIZE(0..8192))
 
-Error data provided primarily for debugging purposes. Systems that emit errors SHOULD include additional explanation or context about the issue.
+Error data either for additional fields relevant for handling a given error or for debugging information.
 
-Protocols built on top of ILP that define behavior for certain errors SHOULD specify the encoding format of error `data`.
-
-Unless otherwise specified, `data` SHOULD be encoded as UTF-8.
+For errors that specify additional data fields (defined below), the data SHOULD be encoded using OER. Other protocols built on top of ILP that define behavior for certain errors SHOULD specify the encoding format of error `data`. Debugging information SHOULD be encoded as UTF-8.
 
 ### ILP Error Codes
 
@@ -279,25 +277,25 @@ Inspired by [HTTP Status Codes](https://tools.ietf.org/html/rfc2616#section-10),
 
 Final errors indicate that the payment is invalid and should not be retried unless the details are changed.
 
-| Code | Name | Description |
-|---|---|---|
-| **F00** | **Bad Request** | Generic sender error. |
-| **F01** | **Invalid Packet** | The ILP packet was syntactically invalid. |
-| **F02** | **Unreachable** | There was no way to forward the payment, because the destination ILP address was wrong or the connector does not have a route to the destination. |
-| **F03** | **Invalid Amount** | The amount is invalid, for example it contains more digits of precision than are available on the destination ledger or the amount is greater than the total amount of the given asset in existence. |
-| **F04** | **Insufficient Destination Amount** | The receiver deemed the amount insufficient, for example you tried to pay a $100 invoice with $10. |
-| **F05** | **Wrong Condition** | The receiver generated a different condition and cannot fulfill the payment. |
-| **F06** | **Unexpected Payment** | The receiver was not expecting a payment like this (the memo and destination address don't make sense in that combination, for example if the receiver does not understand the transport protocol used) |
-| **F07** | **Cannot Receive** | The receiver is unable to accept this payment due to a constraint. For example, the payment would put the receiver above its maximum account balance. |
-| **F08** | **Amount Too Large** | The amount is larger than the maximum size supported by a connector, ledger or the receiver. The producer of this error SHOULD set the error `data` to the concatenation of the following two numbers, each encoded as a 64-bit unsigned, big-endian integer: the amount that arrived and the maximum amount supported by the party producing the error. |
-| **F99** | **Application Error** | Reserved for application layer protocols. Applications MAY use names other than `Application Error`. |
+| Code | Name | Description | Data Fields |
+|---|---|---|---|
+| **F00** | **Bad Request** | Generic sender error. | |
+| **F01** | **Invalid Packet** | The ILP packet was syntactically invalid. | |
+| **F02** | **Unreachable** | There was no way to forward the payment, because the destination ILP address was wrong or the connector does not have a route to the destination. | |
+| **F03** | **Invalid Amount** | The amount is invalid, for example it contains more digits of precision than are available on the destination ledger or the amount is greater than the total amount of the given asset in existence. | |
+| **F04** | **Insufficient Destination Amount** | The receiver deemed the amount insufficient, for example you tried to pay a $100 invoice with $10. | |
+| **F05** | **Wrong Condition** | The receiver generated a different condition and cannot fulfill the payment. | |
+| **F06** | **Unexpected Payment** | The receiver was not expecting a payment like this (the memo and destination address don't make sense in that combination, for example if the receiver does not understand the transport protocol used) | |
+| **F07** | **Cannot Receive** | The receiver is unable to accept this payment due to a constraint. For example, the payment would put the receiver above its maximum account balance. | |
+| **F08** | **Payment Too Large** | The payment is larger than the maximum size supported by a connector, ledger or the receiver. | `SourceAmount` (UInt64), `SourceAmountLimit` (UInt64) |
+| **F99** | **Application Error** | Reserved for application layer protocols. Applications MAY use names other than `Application Error`. | |
 
 #### T__ - Temporary Error
 
 Temporary errors indicate a failure on the part of the receiver or an intermediary system that is unexpected or likely to be resolved soon. Senders SHOULD retry the same payment again, possibly after a short delay.
 
-| Code | Name | Description |
-|---|---|---|
+| Code | Name | Description | Data Fields |
+|---|---|---|---|
 | **T00** | **Internal Error** | A generic unexpected exception. This usually indicates a bug or unhandled error case. |
 | **T01** | **Ledger Unreachable** | The connector has a route or partial route to the destination but was unable to reach the next ledger. Try again later. |
 | **T02** | **Ledger Busy** | The ledger is rejecting requests due to overloading. Try again later. |
@@ -310,8 +308,8 @@ Temporary errors indicate a failure on the part of the receiver or an intermedia
 
 Relative errors indicate that the payment did not have enough of a margin in terms of money or time. However, it is impossible to tell whether the sender did not provide enough error margin or the path suddenly became too slow or illiquid. The sender MAY retry the payment with a larger safety margin.
 
-| Code | Name | Description
-|---|---|---|
+| Code | Name | Description | Data Fields |
+|---|---|---|---|
 | **R00** | **Transfer Timed Out** | The transfer timed out, meaning the next party in the chain did not respond. This could be because you set your timeout too low or because something look longer than it should. The sender MAY try again with a higher expiry, but they SHOULD NOT do this indefinitely or a malicious connector could cause them to tie up their money for an unreasonably long time. |
 | **R01** | **Insufficient Source Amount** | Either the sender did not send enough money or the exchange rate changed before the payment was prepared. The sender MAY try again with a higher amount, but they SHOULD NOT do this indefinitely or a malicious connector could steal money from them. |
 | **R02** | **Insufficient Timeout** | The connector could not forward the payment, because the timeout was too low to subtract its safety margin. The sender MAY try again with a higher expiry, but they SHOULD NOT do this indefinitely or a malicious connector could cause them to tie up their money for an unreasonably long time. |

--- a/0003-interledger-protocol/0003-interledger-protocol.md
+++ b/0003-interledger-protocol/0003-interledger-protocol.md
@@ -1,6 +1,6 @@
 ---
 title: The Interledger Protocol (ILP)
-draft: 4
+draft: 5
 ---
 # Interledger Protocol (ILP)
 
@@ -289,6 +289,7 @@ Final errors indicate that the payment is invalid and should not be retried unle
 | **F05** | **Wrong Condition** | The receiver generated a different condition and cannot fulfill the payment. |
 | **F06** | **Unexpected Payment** | The receiver was not expecting a payment like this (the memo and destination address don't make sense in that combination, for example if the receiver does not understand the transport protocol used) |
 | **F07** | **Cannot Receive** | The receiver is unable to accept this payment due to a constraint. For example, the payment would put the receiver above its maximum account balance. |
+| **F08** | **Amount Too Large** | The amount is larger than the maximum size supported by a connector, ledger or the receiver. The producer of this error SHOULD set the error `data` to the concatenation of the following two numbers, each encoded as a 64-bit unsigned, big-endian integer: the amount that arrived and the maximum amount supported by the party producing the error. |
 | **F99** | **Application Error** | Reserved for application layer protocols. Applications MAY use names other than `Application Error`. |
 
 #### T__ - Temporary Error


### PR DESCRIPTION
connectors may want to limit the maximum size of transfers going through them. this adds an ILP error code to indicate when such a limit is reached. it also recommends including the amount that arrived and the maximum amount supported to help senders adjust the size of their payment appropriately