### PR TITLE
fix: breaking change to PSK spec, to match what ilp-kit does

### DIFF
--- a/0016-pre-shared-key/0016-pre-shared-key.md
+++ b/0016-pre-shared-key/0016-pre-shared-key.md
@@ -184,8 +184,8 @@ ilp_packet = create_ilp_packet({
 // this same derivation when fulfilling the payment. For the sender, the
 // fulfillment is just an intermediate value in calculating the condition.
 
-fulfillment_generator = hmac_sha_256(shared_secret, 'ilp_psk_condition')
-fulfillment = hmac_sha_256(fulfillment_generator, ilp_packet)
+psk_condition_key = hmac_sha_256(shared_secret, 'ilp_psk_condition')
+fulfillment = hmac_sha_256(psk_condition_key, ilp_packet)
 condition = sha_256(fulfillment)
 
 // The sender will now quote and prepare this payment with the condition
@@ -232,8 +232,8 @@ review_payment(private_headers, psk_data, ilp_packet, ... )
 // fulfillment from the shared secret and the ILP packet, and then uses it to
 // fulfill the incoming payment.
 
-fulfillment_generator = hmac_sha_256(shared_secret, 'ilp_psk_condition')
-fulfillment = hmac_sha_256(fulfillment_generator, ilp_packet)
+psk_condition_key = hmac_sha_256(shared_secret, 'ilp_psk_condition')
+fulfillment = hmac_sha_256(psk_condition_key, ilp_packet)
 
 // The receiver submits the fulfillment to execute the incoming transfer.
 ```


### PR DESCRIPTION
This fixes #335. Changes:
* instead of encrypting directly with the `shared_secret`, take the HMAC of the string `'ilp_psk_encryption'` first.
* instead of generating the fulfillment directly with the `shared_secret`, take the HMAC of the string `'ilp_psk_condition'` first.

These are breaking changes, but since there is only one implementation of PSK so far (namely, [ilp-kit](https://github.com/interledgerjs/ilp-kit), which uses the [ilp module](https://www.npmjs.com/package/ilp) for both [encryption](https://github.com/interledgerjs/ilp/blob/master/src/utils/crypto.js#L55) and [fulfillment generation](https://github.com/interledgerjs/ilp/blob/master/src/utils/crypto.js#L48)), I think it's easier for everyone if we leave the version string as `'PSK/1.0'`.

Other alternatives would be to update the version string to `'PSK/2.0'` in the spec and in the code, so that at least we can say we did proper versioning on PSK.

Or to implement what the spec says in ilp-kit, and tag ilp-kit version 5 (ilp module version 12), but after talking to @dappelt I think the intended behavior is what the code does, not what the spec says.