### PR TITLE
ILP packet type for payment chunks

### DIFF
--- a/asn1/InterledgerPacket.asn
+++ b/asn1/InterledgerPacket.asn
@@ -9,6 +9,7 @@ IMPORTS
     FROM GenericTypes
 
     InterledgerProtocolPaymentData,
+    PaymentChunkData,
     InterledgerProtocolErrorData
     FROM InterledgerProtocol
 
@@ -34,7 +35,8 @@ PacketSet PACKET ::= {
     {5 QuoteBySourceAmountResponseData} |
     {6 QuoteByDestinationAmountRequestData} |
     {7 QuoteByDestinationAmountResponseData} |
-    {8 InterledgerProtocolErrorData}
+    {8 InterledgerProtocolErrorData} |
+    {10 PaymentChunkData}
 }
 
 InterledgerPacket ::= SEQUENCE {

--- a/asn1/InterledgerProtocol.asn
+++ b/asn1/InterledgerProtocol.asn
@@ -12,6 +12,23 @@ IMPORTS
     FROM InterledgerTypes
 ;
 
+PaymentChunkData ::= SEQUENCE {
+    -- unique identifier of chunked payment to which this chunk pertains
+    paymentId UInt64,
+    -- target chunk rate (target number of chunks per hour accepted for this payment id)
+    targetChunksAcceptedPerHour UInt64,
+    -- chunk size (can be set to 1 if all chunks are of the same size)
+    chunkSize UInt64,
+    -- Destination ILP Address
+    account Address,
+    -- Information for recipient (transport layer information)
+    data OCTET STRING (SIZE (0..32767)),
+    -- Enable ASN.1 Extensibility
+    extensions SEQUENCE {
+        ...
+    }
+}
+
 InterledgerProtocolPaymentData ::= SEQUENCE {
     -- Amount which must be received at the destination
     amount UInt64,


### PR DESCRIPTION
Obsoletes the amount-less ("best effort") payments proposed in #323.

Solves the problems identified in #340, using the ideas from #333.

By adding a 'chunk size', which the receiver can use to compare the chunks as they arrive. The receiver sees with what transfer amount chunks come in, and only accepts the most profitable ones; the rest is rejected. The ratio between chunks that are accepted and rejected by the receiver is prescribed by the sender in `targetChunksAcceptedPerHour`.