### PR TITLE
Fix size constraints to be whole KiB

### DIFF
--- a/asn1/InterledgerProtocol.asn
+++ b/asn1/InterledgerProtocol.asn
@@ -35,7 +35,7 @@ InterledgerFulfill ::= SEQUENCE {
     fulfillment UInt256,
 
     -- Information for sender (transport layer information)
-    data OCTET STRING (SIZE (0..32767))
+    data OCTET STRING (SIZE (0..32768))
 }
 
 InterledgerReject ::= SEQUENCE {
@@ -46,10 +46,10 @@ InterledgerReject ::= SEQUENCE {
     triggeredBy Address,
 
     -- User-readable error message
-    message UTF8String (SIZE (0..8191)),
+    message UTF8String (SIZE (0..8192)),
 
     -- Machine-readable error data, dependent on code
-    data OCTET STRING (SIZE (0..32767))
+    data OCTET STRING (SIZE (0..32768))
 }
 
 END


### PR DESCRIPTION
ASN.1 size constraints expressed as ranges define a max and min amount. The max amounts previously used were 1 byte short of complete Kibibytes.

8 KiB = 8192 Bytes (Octets or chars when encoded using OER)
32 KiB = 32768 Bytes (Octets)