### PR TITLE
Deprecate RFC 4

### DIFF
--- a/0004-ledger-plugin-interface/0004-ledger-plugin-interface.md
+++ b/0004-ledger-plugin-interface/0004-ledger-plugin-interface.md
@@ -1,7 +1,9 @@
 ---
 title: The Javascript Ledger Plugin Interface
-draft: 10
+deprecated: See IL RFC 24 for the latest version
+draft: FINAL
 ---
+
 # Javascript Ledger Plugin Interface
 
 The Interledger Protocol is a protocol suite for connecting blockchains and other ledgers.

--- a/0004-ledger-plugin-interface/0004-ledger-plugin-interface.md
+++ b/0004-ledger-plugin-interface/0004-ledger-plugin-interface.md
@@ -1,5 +1,5 @@
 ---
-title: The Javascript Ledger Plugin Interface
+title: The Javascript Ledger Plugin Interface 
 deprecated: 0024-ledger-plugin-interface-2
 draft: FINAL
 ---

--- a/0004-ledger-plugin-interface/0004-ledger-plugin-interface.md
+++ b/0004-ledger-plugin-interface/0004-ledger-plugin-interface.md
@@ -1,6 +1,6 @@
 ---
 title: The Javascript Ledger Plugin Interface
-deprecated: "See <a href='../0024-ledger-plugin-interface-2/'>IL RFC 24</a> for the latest version"
+deprecated: 0024-ledger-plugin-interface-2
 draft: FINAL
 ---
 

--- a/0004-ledger-plugin-interface/0004-ledger-plugin-interface.md
+++ b/0004-ledger-plugin-interface/0004-ledger-plugin-interface.md
@@ -1,6 +1,6 @@
 ---
 title: The Javascript Ledger Plugin Interface
-deprecated: See IL RFC 24 for the latest version
+deprecated: "See <a href='../0024-ledger-plugin-interface-2/'>IL RFC 24</a> for the latest version"
 draft: FINAL
 ---
 

--- a/scripts/generate_web.js
+++ b/scripts/generate_web.js
@@ -54,7 +54,7 @@ files.forEach((file) => {
   const fileContent = fs.readFileSync(file, 'utf8')
   const fmContent = fm(fileContent)
 
-  if(!fmContent.attributes.title) {
+  if(!fmContent.attributes.title && !fmContent.attributes.deprecated) {
     buildPass = false;
     console.error("No title specified for " + file)
     return
@@ -62,9 +62,13 @@ files.forEach((file) => {
   const title = fmContent.attributes.title
 
   if(!fmContent.attributes.draft) {
-    buildPass = false;
-    console.error("Draft number required for " + file)
-    return
+    if(fmContent.attributes.deprecated) {
+      fmContent.attributes.draft = 'FINAL'
+    } else {
+      buildPass = false;
+      console.error("Draft number required for " + file)
+      return
+    }
   }
   const draftNumber = fmContent.attributes.draft
 

--- a/scripts/generate_web.js
+++ b/scripts/generate_web.js
@@ -162,13 +162,13 @@ asnFiles.forEach((file) => {
   if (file.endsWith('.md')) {
     const htmlFile = 'web/asn1/index.html'
     const content = marked(fileContent)
-    const renderedHtml = template({ title: 'Interledger ASN.1', content, toc: asnToc })
+    const renderedHtml = template({ title: 'Interledger ASN.1', content, toc: asnToc, deprecated : false })
     console.log('Writing ' + htmlFile)
     fs.writeFileSync(htmlFile, renderedHtml)
   } else {
     const basename = path.basename(file)
     const content = '<pre><code class="nohighlight">' + escape(fileContent) + '</code></pre>'
-    const renderedHtml = template({ title: basename, content, toc: asnToc })
+    const renderedHtml = template({ title: basename, content, toc: asnToc, deprecated: false })
     const htmlFile = 'web/asn1/' + basename + '.html'
     console.log('Writing ' + htmlFile)
     fs.writeFileSync(htmlFile, renderedHtml)

--- a/scripts/generate_web.js
+++ b/scripts/generate_web.js
@@ -54,11 +54,6 @@ files.forEach((file) => {
   const fileContent = fs.readFileSync(file, 'utf8')
   const fmContent = fm(fileContent)
 
-  if(fmContent.attributes.deprecated) {
-    console.log("Skipped deprecated RFC in " + file)
-    return
-  }
-
   if(!fmContent.attributes.title) {
     buildPass = false;
     console.error("No title specified for " + file)
@@ -76,6 +71,13 @@ files.forEach((file) => {
   if((draftNumber^0) !== draftNumber && draftNumber !== 'FINAL') {
     buildPass = false;
     console.error("Invalid draft number found for " + file)
+    return
+  }
+
+  const deprecated = fmContent.attributes.deprecated
+
+  if(deprecated && draftNumber !== 'FINAL') {
+    console.error("Deprecated RFC must be FINAL in " + file)
     return
   }
 
@@ -124,7 +126,7 @@ files.forEach((file) => {
   $('img').addClass('img-responsive')
 
   const content = $.html()
-  const renderedHtml = template({ title, content, toc, rfcNumber, draftNumber })
+  const renderedHtml = template({ title, content, toc, rfcNumber, draftNumber, deprecated })
 
   //Versioning
   if (fs.existsSync(draftFile)) {

--- a/tmpl/rfc.ejs.html
+++ b/tmpl/rfc.ejs.html
@@ -85,6 +85,14 @@
           </nav>
         </div>
         <div class="col-sm-8 markdown-body">
+            <% if (deprecated) { -%>
+          <p class="deprecated">
+            This specification has been deprecated.
+            <% if (typeof deprecated === 'string') { -%>
+              <br/><%= deprecated %>
+            <% } -%>            
+          </p>
+            <% } -%>
           <%- content %>
         </div>
       </div>

--- a/tmpl/rfc.ejs.html
+++ b/tmpl/rfc.ejs.html
@@ -86,8 +86,8 @@
         </div>
         <div class="col-sm-8 markdown-body">
             <% if (deprecated) { -%>
-          <p class="deprecated">
-            This specification has been deprecated.
+          <p class="alert alert-warning" style="margin-top: 35px">
+            <strong>This specification has been deprecated.</strong>
             <% if (typeof deprecated === 'string') { -%>
               <br/><%= deprecated %>
             <% } -%>            

--- a/tmpl/rfc.ejs.html
+++ b/tmpl/rfc.ejs.html
@@ -89,7 +89,7 @@
           <p class="alert alert-warning" style="margin-top: 35px">
             <strong>This specification has been deprecated.</strong>
             <% if (typeof deprecated === 'string') { -%>
-              <br/><%= deprecated %>
+              <br/>It has been replaced by <a href="../<%= deprecated %>">this</a> new specification.
             <% } -%>            
           </p>
             <% } -%>


### PR DESCRIPTION
Update web scripts and template for deprecated specs

@bsteinlo I have updated the spec template to insert a new `<p class="deprecated">...</p>` tag at the top of the page if the spec is deprecated. Right now it has no CSS defined for `.deprecated` but the plan will be to make it banner or similar eye-catching element.

Is this HTML okay to work with?