### PR TITLE
docs(0028) update meta tag to follow html5 syntax

### DIFF
--- a/0028-web-monetization/0028-web-monetization.md
+++ b/0028-web-monetization/0028-web-monetization.md
@@ -1,6 +1,6 @@
 ---
 title: Web Monetization
-draft: 6
+draft: 7
 ---
 
 # Web Monetization
@@ -103,8 +103,7 @@ The `name` of the `<meta>` tags all start with `monetization`. The table below l
 ```html
 <meta
   name="monetization"
-  content="$twitter.xrptipbot.com/Interledger" />
-]
+  content="$twitter.xrptipbot.com/Interledger">
 ```
 
 ##### Iframe to Web-Monetized Page


### PR DESCRIPTION
Update meta tag to not include the / so that it follows the HTML5 syntax for meta tags. https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta