### PR TITLE
Fix the behavior of the Bidirectional Mode

### DIFF
--- a/0000-ilp-ping-protocol/0000-ilp-ping-protocol.md
+++ b/0000-ilp-ping-protocol/0000-ilp-ping-protocol.md
@@ -58,6 +58,8 @@ Note that a Recipient _MAY_ reject the payment if appropriate, for example due t
    - **Condition**: The condition `C`.
    - **Data**: A concatenated series of bytes with the following information:
       - the bytes of the ASCII string `ECHOECHOECHOECHO`. In hexadecimal this value is `0x4543484F4543484F4543484F4543484F`.
+        - Every packet which has the `ECHOECHOECHOECHO` prefix is handled as an echo packet.
+        - If the following bytes after the prefix are not parsable, it will cause a final error.
       - the byte `0x00`
       - The ILP address of the Initiator (i.e., the return address) as an OER-encoded, variable length IA5 string.
 4. Upon receiving the Prepare packet, the Recipient identifies that it is a bidirectional Ping request by confirming the following:


### PR DESCRIPTION
As I talked with @emschwartz  here: https://github.com/emschwartz/interledger-rs/pull/71#discussion_r289644371
it might be better to describe the criteria for determining echo packets.

It might be also better to refer to this from `0027-interledger-protocol-4.md` because the echo prefix is a kind of **reserved** prefix for the Interledger Protocol.