### PR TITLE
Fixes #546

### DIFF
--- a/0029-stream/0029-stream.md
+++ b/0029-stream/0029-stream.md
@@ -438,7 +438,7 @@ In other words, if a sender resends data (e.g. because a packet was lost), it MU
 | Source Asset Code | Utf8String | Asset code of endpoint that sent the frame. |
 | Source Asset Scale | UInt8 | Asset scale of endpoint that sent the frame. |
 
-Asset details exposed by this frame MUST not change during the lifetime of a Connection. Because of this, endpoints that honor `ConnectionAssetDetails` frames SHOULD ignore any repeat `ConnectionAssetDetails` frames for a given Connection.
+Asset details exposed by this frame MUST NOT change during the lifetime of a Connection. Because of this, endpoints that honor `ConnectionAssetDetails` frames SHOULD ignore any repeat `ConnectionAssetDetails` frames for a given Connection.
 
 ### 5.4. Error Codes
 

--- a/0029-stream/0029-stream.md
+++ b/0029-stream/0029-stream.md
@@ -178,8 +178,6 @@ Each endpoint MAY expose their asset details by sending a `ConnectionAssetDetail
 
 Asset details exposed by this frame MUST not change during the lifetime of a Connection.
 
-Endpoints that wish to discover the other endpoint's asset details MAY send a `ConnectionAssetDetails` frame containing its own asset details. The other endpoint MUST respond to this frame with a new `ConnectionAssetDetails` frame containing its own asset details.
-
 ### 4.4. Streams
 
 Once a connection is established, either endpoint can create streams to send money or data.
@@ -435,8 +433,6 @@ In other words, if a sender resends data (e.g. because a packet was lost), it MU
 |---|---|---|
 | Source Asset Code | Utf8String | Asset code of endpoint that sent the frame. |
 | Source Asset Scale | UInt8 | Asset scale of endpoint that sent the frame. |
-
-If an endpoint receives a `ConnectionAssetDetails` frame, the endpoint MUST respond with a new `ConnectionAssetDetails` frame containing its own asset details.
 
 Asset details exposed by this frame MUST NOT change during the lifetime of a Connection.
 

--- a/0029-stream/0029-stream.md
+++ b/0029-stream/0029-stream.md
@@ -178,7 +178,7 @@ Each endpoint MAY expose their asset details by sending a `ConnectionAssetDetail
 
 Asset details exposed by this frame MUST not change during the lifetime of a Connection. Because of this, endpoints that honor `ConnectionAssetDetails` frames SHOULD ignore any repeat `ConnectionAssetDetails` frames for a given Connection.
 
-Endpoints that wish to discover the other endpoint's asset details MAY send a `ConnectionNewAddress` frame to prompt the endpoint to respond with a `ConnectionAssetDetails` frame.
+Endpoints that wish to discover the other endpoint's asset details MAY send a `ConnectionAssetDetails` frame containing their own asset details. The other endpoint MUST respond to this frame with a new `ConnectionAssetDetails` frame containing its own asset details. In order to avoid infinite loops, this response frame MUST be encoded into the Stream packet response that correlates to request containing the initial `ConnectionAssetDetails` frame. 
 
 ### 4.4. Streams
 
@@ -329,9 +329,7 @@ If implementations allow half-open connections, an endpoint MAY continue sending
 
 | Field | Type | Description |
 |---|---|---|
-| Source Address | ILP Address | New ILP address of the endpoint that sent the frame. |
-
-If an endpoint receives a `ConnectionNewAddress` frame, the endpoint MUST respond with a `ConnectionAssetDetails` frame. 
+| Source Address | ILP Address | New ILP address of the endpoint that sent the frame. | 
 
 #### 5.3.3. `ConnectionMaxData` Frame
 
@@ -438,7 +436,9 @@ In other words, if a sender resends data (e.g. because a packet was lost), it MU
 | Source Asset Code | Utf8String | Asset code of endpoint that sent the frame. |
 | Source Asset Scale | UInt8 | Asset scale of endpoint that sent the frame. |
 
-Asset details exposed by this frame MUST NOT change during the lifetime of a Connection. Because of this, endpoints that honor `ConnectionAssetDetails` frames SHOULD ignore any repeat `ConnectionAssetDetails` frames for a given Connection.
+If an endpoint receives a `ConnectionAssetDetails` frame, the endpoint MUST respond with a new `ConnectionAssetDetails` frame containing its own asset details. In order to avoid infinite loops, this response frame MUST be encoded into the Stream packet response that correlates to request containing the initial `ConnectionAssetDetails` frame. 
+
+Asset details exposed by this frame MUST NOT change during the lifetime of a Connection. Because of this, endpoints that honor `ConnectionAssetDetails` frames SHOULD ignore any repeat `ConnectionAssetDetails` frames received on a given Connection.
 
 ### 5.4. Error Codes
 

--- a/0029-stream/0029-stream.md
+++ b/0029-stream/0029-stream.md
@@ -1,6 +1,6 @@
 ---
 title: STREAM - A Multiplexed Money and Data Transport for ILP
-draft: 8
+draft: 8 
 ---
 
 # STREAM: A Multiplexed Money and Data Transport for ILP

--- a/0029-stream/0029-stream.md
+++ b/0029-stream/0029-stream.md
@@ -1,6 +1,6 @@
 ---
 title: STREAM - A Multiplexed Money and Data Transport for ILP
-draft: 7
+draft: 8
 ---
 
 # STREAM: A Multiplexed Money and Data Transport for ILP

--- a/0029-stream/0029-stream.md
+++ b/0029-stream/0029-stream.md
@@ -1,6 +1,6 @@
 ---
 title: STREAM - A Multiplexed Money and Data Transport for ILP
-draft: 9
+draft: 7
 ---
 
 # STREAM: A Multiplexed Money and Data Transport for ILP

--- a/0029-stream/0029-stream.md
+++ b/0029-stream/0029-stream.md
@@ -1,6 +1,6 @@
 ---
 title: STREAM - A Multiplexed Money and Data Transport for ILP
-draft: 8
+draft: 9
 ---
 
 # STREAM: A Multiplexed Money and Data Transport for ILP

--- a/0029-stream/0029-stream.md
+++ b/0029-stream/0029-stream.md
@@ -176,7 +176,7 @@ Implementations SHOULD wait for a valid response (encrypted with the same shared
 
 Each endpoint MAY expose their asset details by sending a `ConnectionAssetDetails` frame. This frame is optional because some use-cases, such as Web Monetization, do not require it.
 
-Asset details exposed by this frame MUST not change during the lifetime of a Connection. Because of this, endpoints that honor `ConnectionAssetDetails` frames SHOULD ignore any repeat `ConnectionAssetDetails` frames for a given Connection.
+Asset details exposed by this frame MUST not change during the lifetime of a Connection.
 
 Endpoints that wish to discover the other endpoint's asset details MAY send a `ConnectionAssetDetails` frame containing its own asset details. The other endpoint MUST respond to this frame with a new `ConnectionAssetDetails` frame containing its own asset details.
 
@@ -438,7 +438,7 @@ In other words, if a sender resends data (e.g. because a packet was lost), it MU
 
 If an endpoint receives a `ConnectionAssetDetails` frame, the endpoint MUST respond with a new `ConnectionAssetDetails` frame containing its own asset details.
 
-Asset details exposed by this frame MUST NOT change during the lifetime of a Connection. Because of this, endpoints that honor `ConnectionAssetDetails` frames SHOULD ignore any repeat `ConnectionAssetDetails` frames received on a given Connection.
+Asset details exposed by this frame MUST NOT change during the lifetime of a Connection.
 
 ### 5.4. Error Codes
 

--- a/0029-stream/0029-stream.md
+++ b/0029-stream/0029-stream.md
@@ -178,7 +178,7 @@ Each endpoint MAY expose their asset details by sending a `ConnectionAssetDetail
 
 Asset details exposed by this frame MUST not change during the lifetime of a Connection. Because of this, endpoints that honor `ConnectionAssetDetails` frames SHOULD ignore any repeat `ConnectionAssetDetails` frames for a given Connection.
 
-Endpoints that wish to discover the other endpoint's asset details MAY send a `ConnectionAssetDetails` frame containing their own asset details. The other endpoint MUST respond to this frame with a new `ConnectionAssetDetails` frame containing its own asset details. In order to avoid infinite loops, this response frame MUST be encoded into the Stream packet response that correlates to request containing the initial `ConnectionAssetDetails` frame. 
+Endpoints that wish to discover the other endpoint's asset details MAY send a `ConnectionAssetDetails` frame containing its own asset details. The other endpoint MUST respond to this frame with a new `ConnectionAssetDetails` frame containing its own asset details.
 
 ### 4.4. Streams
 

--- a/0029-stream/0029-stream.md
+++ b/0029-stream/0029-stream.md
@@ -327,7 +327,7 @@ If implementations allow half-open connections, an endpoint MAY continue sending
 
 | Field | Type | Description |
 |---|---|---|
-| Source Address | ILP Address | New ILP address of the endpoint that sent the frame. | 
+| Source Address | ILP Address | New ILP address of the endpoint that sent the frame. |
 
 #### 5.3.3. `ConnectionMaxData` Frame
 

--- a/0029-stream/0029-stream.md
+++ b/0029-stream/0029-stream.md
@@ -174,7 +174,7 @@ Implementations SHOULD wait for a valid response (encrypted with the same shared
 
 #### 4.3.1. Connection Asset Details
 
-Each endpoint MAY expose their asset details by sending a `ConnectionAssetDetails` frame. This frame is optional because some use-cases, such as Web Monetization, do not require it.
+Each endpoint MAY expose their asset details by sending a `ConnectionAssetDetails` frame. This frame is optional because some use-cases do not require it.
 
 Asset details exposed by this frame MUST not change during the lifetime of a Connection.
 

--- a/0029-stream/0029-stream.md
+++ b/0029-stream/0029-stream.md
@@ -1,6 +1,6 @@
 ---
 title: STREAM - A Multiplexed Money and Data Transport for ILP
-draft: 7
+draft: 8
 ---
 
 # STREAM: A Multiplexed Money and Data Transport for ILP
@@ -174,7 +174,11 @@ Implementations SHOULD wait for a valid response (encrypted with the same shared
 
 #### 4.3.1. Connection Asset Details
 
-Each endpoint MAY expose their asset details by sending a `ConnectionAssetDetails` frame.
+Each endpoint MAY expose their asset details by sending a `ConnectionAssetDetails` frame. This frame is optional because some use-cases, such as Web Monetization, do not require it.
+
+Asset details exposed by this frame MUST not change during the lifetime of a Connection. Because of this, endpoints that honor `ConnectionAssetDetails` frames SHOULD ignore any repeat `ConnectionAssetDetails` frames for a given Connection.
+
+Endpoints that wish to discover the other endpoint's asset details MAY send a `ConnectionNewAddress` frame to prompt the endpoint to respond with a `ConnectionAssetDetails` frame.
 
 ### 4.4. Streams
 
@@ -327,6 +331,8 @@ If implementations allow half-open connections, an endpoint MAY continue sending
 |---|---|---|
 | Source Address | ILP Address | New ILP address of the endpoint that sent the frame. |
 
+If an endpoint receives a `ConnectionNewAddress` frame, the endpoint MUST respond with a `ConnectionAssetDetails` frame. 
+
 #### 5.3.3. `ConnectionMaxData` Frame
 
 | Field | Type | Description |
@@ -431,6 +437,8 @@ In other words, if a sender resends data (e.g. because a packet was lost), it MU
 |---|---|---|
 | Source Asset Code | Utf8String | Asset code of endpoint that sent the frame. |
 | Source Asset Scale | UInt8 | Asset scale of endpoint that sent the frame. |
+
+Asset details exposed by this frame MUST not change during the lifetime of a Connection. Because of this, endpoints that honor `ConnectionAssetDetails` frames SHOULD ignore any repeat `ConnectionAssetDetails` frames for a given Connection.
 
 ### 5.4. Error Codes
 

--- a/0029-stream/0029-stream.md
+++ b/0029-stream/0029-stream.md
@@ -436,7 +436,7 @@ In other words, if a sender resends data (e.g. because a packet was lost), it MU
 | Source Asset Code | Utf8String | Asset code of endpoint that sent the frame. |
 | Source Asset Scale | UInt8 | Asset scale of endpoint that sent the frame. |
 
-If an endpoint receives a `ConnectionAssetDetails` frame, the endpoint MUST respond with a new `ConnectionAssetDetails` frame containing its own asset details. In order to avoid infinite loops, this response frame MUST be encoded into the Stream packet response that correlates to request containing the initial `ConnectionAssetDetails` frame. 
+If an endpoint receives a `ConnectionAssetDetails` frame, the endpoint MUST respond with a new `ConnectionAssetDetails` frame containing its own asset details.
 
 Asset details exposed by this frame MUST NOT change during the lifetime of a Connection. Because of this, endpoints that honor `ConnectionAssetDetails` frames SHOULD ignore any repeat `ConnectionAssetDetails` frames received on a given Connection.
 


### PR DESCRIPTION
Fixes #546 by clarifying the STREAM RFC.

* Clarify that `ConnectionAssetDetails` MUST not change during the lifetime of a Connection.

Signed-off-by: sappenin <sappenin@gmail.com>