### PR TITLE
docs(0009): recommend cors headers for spsp

### DIFF
--- a/0009-simple-payment-setup-protocol/0009-simple-payment-setup-protocol.md
+++ b/0009-simple-payment-setup-protocol/0009-simple-payment-setup-protocol.md
@@ -1,7 +1,7 @@
 ---
 title: The Simple Payment Setup Protocol (SPSP)
 type: working-draft
-draft: 11
+draft: 12
 ---
 # Simple Payment Setup Protocol (SPSP)
 
@@ -62,6 +62,19 @@ GET /.well-known/pay HTTP/1.1
 Host: example.com
 Accept: application/spsp4+json, application/spsp+json
 ```
+
+##### Request Headers to Support Web Monetization Polyfills
+
+[Web Monetization](../0028-web-monetization/0028-web-monetization.md) polyfills may query SPSP from a non-privileged context they are implemented as a script rather than a browser extension. Sites may choose to use a script-based polyfill to enable Web Monetization for their visitors without requiring any browser extension or browser support.
+
+In this situation, [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) headers are necessary to make the SPSP server reachable. If CORS headers are not included, the SPSP query will be rejected and Web Monetization will fail to initialize.
+
+SPSP servers SHOULD expose the CORS headers listed below on `GET <SPSP Endpoint>` **and `OPTIONS <SPSP Endpoint>`**.
+
+| Header | Value |
+|:---|:---|
+| `Access-Control-Allow-Origin` | `*` |
+| `Access-Control-Allow-Headers` | `web-monetization-id` |
 
 ##### Request Headers to Support STREAM Receipts
 

--- a/0009-simple-payment-setup-protocol/0009-simple-payment-setup-protocol.md
+++ b/0009-simple-payment-setup-protocol/0009-simple-payment-setup-protocol.md
@@ -65,7 +65,7 @@ Accept: application/spsp4+json, application/spsp+json
 
 ##### Request Headers to Support Web Monetization Polyfills
 
-[Web Monetization](../0028-web-monetization/0028-web-monetization.md) polyfills may query SPSP from a non-privileged context they are implemented as a script rather than a browser extension. Sites may choose to use a script-based polyfill to enable Web Monetization for their visitors without requiring any browser extension or browser support.
+[Web Monetization](../0028-web-monetization/0028-web-monetization.md) polyfills may query SPSP from a non-privileged context if they are implemented as a script rather than a browser extension. Sites may choose to use a script-based polyfill to enable Web Monetization for their visitors without requiring any browser extension or browser support.
 
 In this situation, [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) headers are necessary to make the SPSP server reachable. If CORS headers are not included, the SPSP query will be rejected and Web Monetization will fail to initialize.
 


### PR DESCRIPTION
It's an unwritten rule right now that SPSP servers include CORS headers to allow Web Monetization polyfills to function.

All ILP enabled wallets currently support this behavior already, but including it here will make it easier for future ILP enabled wallets to follow this recommendation.